### PR TITLE
ci(release): compare 'latest' release to most recent date-stamped directory

### DIFF
--- a/.github/workflows/validate_latest.yml
+++ b/.github/workflows/validate_latest.yml
@@ -6,11 +6,14 @@ on:
       - main
     paths:
       - 'releases/**'
+      - '.github/workflows/validate_latest.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'releases/**'
+      - '.github/workflows/validate_latest.yml'
+
 
 jobs:
   validate-latest-release:

--- a/.github/workflows/validate_latest.yml
+++ b/.github/workflows/validate_latest.yml
@@ -1,0 +1,31 @@
+name: Validate latest release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'releases/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'releases/**'
+
+jobs:
+  validate-latest-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Identify highest version releases directory
+        id: find-version
+        run: |
+          latest_version=$(ls releases/ | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' | sort | tail -n1)
+          echo "latest_version=$latest_version" >> "$GITHUB_OUTPUT"
+          echo "Latest version directory: $latest_version"
+
+      - name: Compare latest to highest version
+        run: |
+          diff_output=$(diff -r releases/latest releases/${{ steps.find-version.outputs.latest_version }}) || (echo "$diff_output"; exit 1)
+          echo "✅ 'latest' releases matches highest version: ${{ steps.find-version.outputs.latest_version }}"


### PR DESCRIPTION
This action ensures that `latest` is always an exact copy of the most recent date-stamped release (e.g. currently 2025-07-17, but will automatically track the latest date).

Closes #2 