### PR TITLE
feat(ccpt): add Carbon Credit Procurement Template framework

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Carbon Credit Procurement Template — Preview</title>
+<title>Template for Carbon Credit Procurement — Preview</title>
 <style>
   :root {
     --bg: #f7f7f5;
@@ -390,10 +390,10 @@
 <header>
   <div class="mockup-banner" role="alert">
     <span class="icon" aria-hidden="true">⚠</span>
-    This form is a <strong>mock-up</strong> to better visualize and validate answers against the CCPT.
+    This form is a <strong>mock-up</strong> to better visualize and validate answers against the TCCP.
     It <strong>does not save or store data</strong>, and it is <strong>not part of any specific RFP</strong>.
   </div>
-  <h1>Carbon Credit Procurement Template <span class="preview-badge" title="This is a preview build — not for live procurement use.">Preview</span></h1>
+  <h1>Template for Carbon Credit Procurement <span class="preview-badge" title="This is a preview build — not for live procurement use.">Preview</span></h1>
   <p>Fill in answers below. Inputs are generated from the selected framework's JSON schema and validated against it.</p>
   <div class="controls">
     <div>
@@ -401,7 +401,7 @@
       <select id="framework">
         <option value="../releases/ccdf/2025-07-17/ccdf.json">CCDF (2025-07-17)</option>
         <option value="../releases/seccdf/2025-09-05/seccdf.json">SECCDF (2025-09-05)</option>
-        <option value="../releases/ccpt/2026-08-05/ccpt.json" selected>CCPT (2026-08-05)</option>
+        <option value="../releases/tccp/2026-08-05/tccp.json" selected>TCCP (2026-08-05)</option>
       </select>
     </div>
     <div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Carbon Credit Procurement Template</title>
+<title>Carbon Credit Procurement Template — Preview</title>
 <style>
   :root {
     --bg: #f7f7f5;
@@ -33,6 +33,20 @@
     position: sticky; top: 0; z-index: 10;
   }
   header h1 { margin: 0 0 4px 0; font-size: 18px; }
+  .preview-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.10em;
+    text-transform: uppercase;
+    padding: 3px 9px;
+    margin-left: 8px;
+    vertical-align: 2px;
+    background: #fff2c9;
+    color: #7a4400;
+    border: 1px solid #e8b866;
+    border-radius: 999px;
+  }
   header p { margin: 0; color: var(--muted); font-size: 13px; }
   .controls {
     display: flex; flex-wrap: wrap; gap: 12px; align-items: center;
@@ -348,15 +362,15 @@
 </head>
 <body>
 <header>
-  <h1>Carbon Credit Procurement Template</h1>
+  <h1>Carbon Credit Procurement Template <span class="preview-badge" title="This is a preview build — not for live procurement use.">Preview</span></h1>
   <p>Fill in answers below. Inputs are generated from the selected framework's JSON schema and validated against it.</p>
   <div class="controls">
     <div>
       <label for="framework">Framework</label>
       <select id="framework">
-        <option value="releases/ccdf/2025-07-17/ccdf.json">CCDF (2025-07-17)</option>
-        <option value="releases/seccdf/2025-09-05/seccdf.json">SECCDF (2025-09-05)</option>
-        <option value="releases/ccpt/2026-08-05/ccpt.json" selected>CCPT (2026-08-05)</option>
+        <option value="../releases/ccdf/2025-07-17/ccdf.json">CCDF (2025-07-17)</option>
+        <option value="../releases/seccdf/2025-09-05/seccdf.json">SECCDF (2025-09-05)</option>
+        <option value="../releases/ccpt/2026-08-05/ccpt.json" selected>CCPT (2026-08-05)</option>
       </select>
     </div>
     <div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,6 +32,24 @@
     padding: 20px 24px;
     position: sticky; top: 0; z-index: 10;
   }
+  .mockup-banner {
+    background: #ffcc4d;
+    color: #3d2400;
+    border-bottom: 2px solid #b8790a;
+    padding: 10px 24px;
+    margin: -20px -24px 14px -24px;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.45;
+    text-align: center;
+  }
+  .mockup-banner strong { font-weight: 700; }
+  .mockup-banner .icon {
+    display: inline-block;
+    margin-right: 6px;
+    font-size: 15px;
+    vertical-align: -1px;
+  }
   header h1 { margin: 0 0 4px 0; font-size: 18px; }
   .preview-badge {
     display: inline-block;
@@ -339,6 +357,14 @@
     body { background: #fff; }
     header { position: static; border-bottom: 1px solid #000; padding: 8px 0; }
     header .controls, .actions, .stage-nav, #result-panel, #status, footer { display: none !important; }
+    .mockup-banner {
+      background: #fff !important;
+      color: #000 !important;
+      border: 2px solid #000;
+      margin: 0 0 12px 0;
+      padding: 8px 12px;
+      text-align: left;
+    }
     main { max-width: 100%; padding: 0; }
     .step { border: none; padding: 8px 0; margin-bottom: 8px; break-inside: avoid; page-break-inside: avoid; }
     .step > h2 { font-size: 15px; border-bottom: 1px solid #000; padding-bottom: 4px; }
@@ -362,6 +388,11 @@
 </head>
 <body>
 <header>
+  <div class="mockup-banner" role="alert">
+    <span class="icon" aria-hidden="true">⚠</span>
+    This form is a <strong>mock-up</strong> to better visualize and validate answers against the CCPT.
+    It <strong>does not save or store data</strong>, and it is <strong>not part of any specific RFP</strong>.
+  </div>
   <h1>Carbon Credit Procurement Template <span class="preview-badge" title="This is a preview build — not for live procurement use.">Preview</span></h1>
   <p>Fill in answers below. Inputs are generated from the selected framework's JSON schema and validated against it.</p>
   <div class="controls">

--- a/index.html
+++ b/index.html
@@ -159,6 +159,97 @@
     text-align: left;
   }
   .field table th { background: #fafaf8; font-weight: 600; }
+  .field table th .col-hint {
+    display: block;
+    font-style: italic;
+    font-weight: 400;
+    color: var(--muted);
+    font-size: 12px;
+    margin-top: 2px;
+  }
+  .step-docs {
+    font-size: 13px;
+    color: var(--ink);
+    background: #f4f4f0;
+    border-left: 3px solid var(--line);
+    padding: 8px 12px;
+    margin: 0 0 12px 0;
+    border-radius: 0 6px 6px 0;
+  }
+  .step-docs strong { color: var(--muted); font-weight: 600; }
+  .step-about {
+    font-size: 13px;
+    color: var(--muted);
+    margin: 0 0 16px 0;
+  }
+  .step-about > summary {
+    cursor: pointer;
+    color: var(--accent);
+    font-size: 12px;
+    padding: 2px 0;
+    user-select: none;
+  }
+  .step-about > summary:hover { text-decoration: underline; }
+  .step-about > p { margin: 6px 0 0 0; }
+
+  /* Multi-select chip component (top-level array fields + table cells) */
+  .ms { display: flex; flex-direction: column; gap: 4px; }
+  .ms-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+  .ms-chips:empty { display: none; }
+  .ms-chip {
+    display: inline-flex; align-items: center; gap: 2px;
+    padding: 2px 4px 2px 8px;
+    background: #eef4ff;
+    border: 1px solid #cbdcfb;
+    border-radius: 12px;
+    font-size: 12px; line-height: 1.4;
+    color: #1a56b8;
+    max-width: 100%;
+  }
+  .ms-chip-label {
+    max-width: 220px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .ms-chip-x {
+    background: none; border: none; cursor: pointer;
+    color: #1a56b8;
+    padding: 0 4px;
+    font: inherit; font-size: 14px; line-height: 1;
+  }
+  .ms-chip-x:hover { color: var(--error); }
+  .ms-input-wrap { position: relative; }
+  .ms-input {
+    width: 100%; padding: 4px 8px;
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    font: inherit; font-size: 13px;
+    background: #fff;
+  }
+  .ms-dropdown {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    box-shadow: 0 4px 14px rgba(0,0,0,0.10);
+    max-height: 240px;
+    overflow-y: auto;
+    z-index: 100;
+    padding: 4px 0;
+  }
+  .ms-option {
+    padding: 5px 10px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .ms-option:hover, .ms-option.active { background: #f0f5ff; }
+  .ms-hint {
+    padding: 5px 10px;
+    color: var(--muted);
+    font-size: 12px;
+    font-style: italic;
+  }
+  .field table td .ms { min-width: 180px; }
+  .field table td .ms-chip { font-size: 11px; padding: 1px 3px 1px 6px; }
+  .field table td .ms-chip-label { max-width: 140px; }
   .field table input, .field table select, .field table textarea {
     width: 100%;
     border: none;
@@ -266,7 +357,7 @@ async function loadFrameworkFromUrl(url) {
     const res = await fetch(url, { cache: "no-store" });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const doc = await res.json();
-    setFramework(doc);
+    await setFramework(doc);
     setStatus(`Loaded ${doc.title} v${doc.version}.`, "ok");
   } catch (e) {
     setStatus(
@@ -276,7 +367,8 @@ async function loadFrameworkFromUrl(url) {
   }
 }
 
-function setFramework(doc) {
+async function setFramework(doc) {
+  await resolveCdopRefs(doc);
   state.schema = doc;
   state.topicIndex = 0;
   const topicSel = $("#topic");
@@ -285,6 +377,65 @@ function setFramework(doc) {
     topicSel.appendChild(el("option", { value: i }, t.label || t.name));
   });
   renderForm();
+}
+
+// ---------- CDOP enum resolver ----------
+// Fields can declare options as { "$cdopRef": { "schema": "<name>", "pointer": "<json-pointer>", "appendOther": true } }.
+// On load, we fetch the referenced CDOP schema from jsDelivr (cached per schema), resolve the pointer to its `enum`,
+// and mutate the field's options to the resolved string array. Renderer sees a plain options array either way.
+const CDOP_BASE = "https://cdn.jsdelivr.net/gh/Carbon-Data-Open-Protocol/Carbon-Data-Open-Protocol@main/json_schema";
+const cdopSchemaCache = new Map();
+
+function fetchCdopSchema(name) {
+  if (cdopSchemaCache.has(name)) return cdopSchemaCache.get(name);
+  const p = fetch(`${CDOP_BASE}/${name}.schema.json`).then(r => {
+    if (!r.ok) throw new Error(`${name}.schema.json ${r.status}`);
+    return r.json();
+  });
+  cdopSchemaCache.set(name, p);
+  return p;
+}
+
+function resolveJsonPointer(doc, pointer) {
+  if (!pointer || pointer === "/") return doc;
+  const parts = pointer.replace(/^\//, "").split("/").map(p => p.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let cur = doc;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+async function resolveCdopRefs(doc) {
+  const refs = [];
+  const walk = (node) => {
+    if (Array.isArray(node)) { node.forEach(walk); return; }
+    if (!node || typeof node !== "object") return;
+    for (const [k, v] of Object.entries(node)) {
+      if (v && typeof v === "object" && !Array.isArray(v) && v.$cdopRef) {
+        refs.push({ parent: node, key: k, ref: v.$cdopRef });
+      } else {
+        walk(v);
+      }
+    }
+  };
+  walk(doc);
+  if (!refs.length) return;
+  await Promise.all(refs.map(async ({ parent, key, ref }) => {
+    try {
+      const schema = await fetchCdopSchema(ref.schema);
+      const node = resolveJsonPointer(schema, ref.pointer);
+      const enumVals = node && Array.isArray(node.enum) ? node.enum : null;
+      if (!enumVals) throw new Error(`no enum at ${ref.pointer}`);
+      const opts = enumVals.slice();
+      if (ref.appendOther) opts.push("Other");
+      parent[key] = opts;
+    } catch (e) {
+      console.warn(`CDOP ref ${ref.schema}${ref.pointer} failed:`, e.message);
+      parent[key] = [];
+    }
+  }));
 }
 
 // ---------- Rendering ----------
@@ -300,6 +451,18 @@ function renderForm() {
     const stepEl = el("section", { class: "step" },
       el("h2", {}, step.label || step.name),
     );
+    if (step.complementaryDocs) {
+      stepEl.appendChild(el("p", { class: "step-docs" },
+        el("strong", {}, "Suggested documentation: "),
+        step.complementaryDocs,
+      ));
+    }
+    if (step.relevanceAndUse) {
+      stepEl.appendChild(el("details", { class: "step-about" },
+        el("summary", {}, "About this section"),
+        el("p", {}, step.relevanceAndUse),
+      ));
+    }
     (step.sections || []).forEach(section => {
       const secEl = el("div", { class: "section" });
       if (section.label && section.label.trim()) {
@@ -386,17 +549,11 @@ function renderField(field) {
     return wrap;
   }
 
-  // Array with options → multi-checkbox group
+  // Array with options → chip multi-select with typeahead
   if (type === "array" && hasOptions) {
-    const group = el("div", { class: "options-group", "data-role": "checkbox-array" });
-    field.options.forEach((o, i) => {
-      const cbId = `${fieldId(field)}_${i}`;
-      group.appendChild(el("label", { for: cbId },
-        el("input", { type: "checkbox", id: cbId, value: o }),
-        el("span", {}, o),
-      ));
-    });
-    wrap.appendChild(group);
+    const ms = makeMultiSelect(field.options);
+    ms.setAttribute("data-role", "multi-select");
+    wrap.appendChild(ms);
     return wrap;
   }
 
@@ -433,6 +590,126 @@ function renderField(field) {
   return wrap;
 }
 
+// Chip multi-select with typeahead. Backs both top-level array fields and
+// multi-select table cells. Exposes _getValues()/_setValues(vals) on the wrapper.
+function makeMultiSelect(options, initial = []) {
+  const wrap = el("div", { class: "ms" });
+  const chipsEl = el("div", { class: "ms-chips" });
+  const inputWrap = el("div", { class: "ms-input-wrap" });
+  const input = el("input", { type: "text", class: "ms-input", placeholder: "type to search…" });
+  const dropdown = el("div", { class: "ms-dropdown", style: "display:none;" });
+  inputWrap.appendChild(input);
+  inputWrap.appendChild(dropdown);
+  wrap.appendChild(chipsEl);
+  wrap.appendChild(inputWrap);
+
+  const state = { selected: new Set(initial), activeIdx: -1, filtered: [] };
+  const MAX = 100;
+
+  const renderChips = () => {
+    chipsEl.innerHTML = "";
+    for (const v of state.selected) {
+      const chip = el("span", { class: "ms-chip" });
+      chip.appendChild(el("span", { class: "ms-chip-label", title: v }, v));
+      const x = el("button", { type: "button", class: "ms-chip-x", title: "Remove" }, "×");
+      x.addEventListener("click", (e) => {
+        e.preventDefault(); e.stopPropagation();
+        state.selected.delete(v);
+        renderChips();
+        if (dropdown.style.display !== "none") renderDropdown();
+      });
+      chip.appendChild(x);
+      chipsEl.appendChild(chip);
+    }
+  };
+
+  const positionDropdown = () => {
+    const rect = input.getBoundingClientRect();
+    dropdown.style.position = "fixed";
+    dropdown.style.top = `${rect.bottom + 2}px`;
+    dropdown.style.left = `${rect.left}px`;
+    dropdown.style.minWidth = `${Math.max(rect.width, 220)}px`;
+    dropdown.style.maxWidth = `${Math.min(window.innerWidth - rect.left - 12, 480)}px`;
+  };
+
+  const renderDropdown = () => {
+    dropdown.innerHTML = "";
+    const q = input.value.toLowerCase().trim();
+    const remaining = options.filter(o => !state.selected.has(o));
+    state.filtered = q ? remaining.filter(o => o.toLowerCase().includes(q)) : remaining;
+    state.activeIdx = state.filtered.length > 0 ? 0 : -1;
+    const visible = state.filtered.slice(0, MAX);
+    visible.forEach((o, i) => {
+      const item = el("div", { class: "ms-option" + (i === state.activeIdx ? " active" : "") });
+      item.textContent = o;
+      item.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        pick(o);
+      });
+      item.addEventListener("mouseenter", () => {
+        state.activeIdx = i;
+        dropdown.querySelectorAll(".ms-option").forEach((el, idx) => el.classList.toggle("active", idx === i));
+      });
+      dropdown.appendChild(item);
+    });
+    if (state.filtered.length > MAX) {
+      dropdown.appendChild(el("div", { class: "ms-hint" }, `${state.filtered.length - MAX} more — keep typing to narrow`));
+    }
+    if (state.filtered.length === 0) {
+      dropdown.appendChild(el("div", { class: "ms-hint" }, q ? "no matches" : "all selected"));
+    }
+    dropdown.style.display = "block";
+    positionDropdown();
+  };
+
+  const pick = (o) => {
+    state.selected.add(o);
+    input.value = "";
+    renderChips();
+    renderDropdown();
+    input.focus();
+  };
+
+  const closeDropdown = () => { dropdown.style.display = "none"; };
+
+  input.addEventListener("focus", renderDropdown);
+  input.addEventListener("input", renderDropdown);
+  input.addEventListener("blur", () => setTimeout(closeDropdown, 120));
+  input.addEventListener("keydown", (e) => {
+    if (dropdown.style.display === "none") return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      state.activeIdx = Math.min(state.activeIdx + 1, Math.min(state.filtered.length, MAX) - 1);
+      dropdown.querySelectorAll(".ms-option").forEach((el, i) => el.classList.toggle("active", i === state.activeIdx));
+      dropdown.querySelector(".ms-option.active")?.scrollIntoView({ block: "nearest" });
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      state.activeIdx = Math.max(state.activeIdx - 1, 0);
+      dropdown.querySelectorAll(".ms-option").forEach((el, i) => el.classList.toggle("active", i === state.activeIdx));
+      dropdown.querySelector(".ms-option.active")?.scrollIntoView({ block: "nearest" });
+    } else if (e.key === "Enter") {
+      if (state.activeIdx >= 0 && state.filtered[state.activeIdx]) {
+        e.preventDefault();
+        pick(state.filtered[state.activeIdx]);
+      }
+    } else if (e.key === "Escape") {
+      closeDropdown();
+    } else if (e.key === "Backspace" && input.value === "" && state.selected.size > 0) {
+      const last = Array.from(state.selected).pop();
+      state.selected.delete(last);
+      renderChips();
+      renderDropdown();
+    }
+  });
+  window.addEventListener("scroll", closeDropdown, true);
+
+  wrap._getValues = () => Array.from(state.selected);
+  wrap._setValues = (vals) => { state.selected = new Set(vals || []); renderChips(); };
+
+  renderChips();
+  return wrap;
+}
+
 function makeArrayRow(list) {
   const input = el("input", { type: "text" });
   const remove = el("button", { type: "button", class: "mini", onclick: () => {
@@ -448,7 +725,11 @@ function renderTable(field, columns) {
   const table = el("table");
   const thead = el("thead");
   const headRow = el("tr");
-  columns.forEach(c => headRow.appendChild(el("th", {}, c.label || c.name)));
+  columns.forEach(c => {
+    const th = el("th", {}, c.label || c.name);
+    if (c.description) th.appendChild(el("span", { class: "col-hint" }, c.description));
+    headRow.appendChild(th);
+  });
   headRow.appendChild(el("th", { style: "width: 40px;" }, ""));
   thead.appendChild(headRow);
   table.appendChild(thead);
@@ -463,7 +744,11 @@ function renderTable(field, columns) {
     columns.forEach(c => {
       const cell = el("td");
       const hasOpts = Array.isArray(c.options) && c.options.length > 0 && typeof c.options[0] === "string";
-      if (hasOpts) {
+      if (hasOpts && c.type === "array") {
+        const ms = makeMultiSelect(c.options);
+        ms.setAttribute("data-col", c.name);
+        cell.appendChild(ms);
+      } else if (hasOpts) {
         const s = el("select", { "data-col": c.name },
           el("option", { value: "" }, "—"),
           ...c.options.map(o => el("option", { value: o }, o)),
@@ -546,6 +831,15 @@ function readField(fEl, field) {
       for (const c of columns) {
         const input = tr.querySelector(`[data-col="${c.name}"]`);
         if (!input) continue;
+        // Multi-select cell (chip component)
+        if (typeof input._getValues === "function") {
+          const values = input._getValues();
+          for (const v of values) {
+            if (!c.options.includes(v)) return { error: `Row ${rowIdx}, column "${c.label || c.name}": "${v}" is not one of ${c.options.join(", ")}` };
+          }
+          if (values.length > 0) { row[c.name] = values; hasAnything = true; }
+          continue;
+        }
         if (c.type === "boolean") {
           if (input.checked) { row[c.name] = true; hasAnything = true; }
           continue;
@@ -608,10 +902,10 @@ function readField(fEl, field) {
     return { value: n };
   }
 
-  // Array with options → multi-checkbox
+  // Array with options → chip multi-select
   if (type === "array" && hasOptions) {
-    const group = fEl.querySelector('[data-role="checkbox-array"]');
-    const values = [...group.querySelectorAll("input[type=checkbox]:checked")].map(c => c.value);
+    const ms = fEl.querySelector('[data-role="multi-select"]');
+    const values = ms._getValues();
     for (const v of values) {
       if (!field.options.includes(v)) return { error: `"${v}" is not one of ${field.options.join(", ")}` };
     }

--- a/index.html
+++ b/index.html
@@ -895,7 +895,12 @@ function makeMultiSelect(options, initial = []) {
       renderDropdown();
     }
   });
-  window.addEventListener("scroll", closeDropdown, true);
+  // Close on outer-page scroll (dropdown is position:fixed and would detach from the input),
+  // but not when the user is scrolling within the dropdown itself.
+  window.addEventListener("scroll", (e) => {
+    if (dropdown.contains(e.target)) return;
+    closeDropdown();
+  }, true);
 
   wrap._getValues = () => Array.from(state.selected);
   wrap._setValues = (vals) => { state.selected = new Set(vals || []); renderChips(); };

--- a/index.html
+++ b/index.html
@@ -292,6 +292,31 @@
     max-height: 520px;
     overflow: auto;
   }
+  .advanced-controls {
+    font-size: 13px;
+    color: var(--muted);
+    margin-left: auto;
+  }
+  .advanced-controls > summary {
+    cursor: pointer;
+    color: var(--accent);
+    user-select: none;
+    padding: 6px 10px;
+    border-radius: 6px;
+  }
+  .advanced-controls > summary:hover { background: #f0f0ee; }
+  .advanced-controls[open] > summary { color: var(--ink); }
+  .advanced-body {
+    display: flex; flex-direction: column; gap: 6px;
+    padding: 10px 12px;
+    margin-top: 6px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #fafaf8;
+    max-width: 480px;
+  }
+  .advanced-body label { color: var(--muted); font-size: 12px; }
+
   .actions { display: flex; gap: 8px; margin: 16px 0; }
   footer { text-align: center; color: var(--muted); font-size: 12px; padding: 20px; }
 
@@ -338,10 +363,13 @@
       <label for="topic">Stage</label>
       <select id="topic"><option>Loading…</option></select>
     </div>
-    <div>
-      <label for="schema-file">Or load file</label>
-      <input type="file" id="schema-file" accept="application/json,.json">
-    </div>
+    <details class="advanced-controls">
+      <summary>Advanced</summary>
+      <div class="advanced-body">
+        <label for="schema-file">Load schema from file (developer use — pick a framework JSON to preview it)</label>
+        <input type="file" id="schema-file" accept="application/json,.json">
+      </div>
+    </details>
   </div>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Carbon Disclosure &amp; Procurement Form</title>
+<title>Carbon Credit Procurement Template</title>
 <style>
   :root {
     --bg: #f7f7f5;
@@ -257,6 +257,21 @@
     font: inherit;
     background: transparent;
   }
+  .radio-group { display: flex; flex-direction: column; gap: 4px; }
+  .radio-row {
+    display: flex; align-items: flex-start; gap: 8px;
+    padding: 6px 8px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: normal;
+    font-size: 14px;
+  }
+  .radio-row:hover { background: #f9f9f7; }
+  .radio-row input[type=radio] { margin-top: 3px; flex-shrink: 0; }
+  .radio-text { flex: 1; }
+
   .field.has-error .field-label { color: var(--error); }
   .field.has-error input,
   .field.has-error select,
@@ -279,11 +294,36 @@
   }
   .actions { display: flex; gap: 8px; margin: 16px 0; }
   footer { text-align: center; color: var(--muted); font-size: 12px; padding: 20px; }
+
+  @media print {
+    :root { --bg: #fff; --panel: #fff; }
+    body { background: #fff; }
+    header { position: static; border-bottom: 1px solid #000; padding: 8px 0; }
+    header .controls, .actions, .stage-nav, #result-panel, #status, footer { display: none !important; }
+    main { max-width: 100%; padding: 0; }
+    .step { border: none; padding: 8px 0; margin-bottom: 8px; break-inside: avoid; page-break-inside: avoid; }
+    .step > h2 { font-size: 15px; border-bottom: 1px solid #000; padding-bottom: 4px; }
+    .section { border-top: 1px solid #ccc; padding: 8px 0; break-inside: avoid; page-break-inside: avoid; }
+    .field { break-inside: avoid; page-break-inside: avoid; margin-bottom: 10px; }
+    .field .type-tag { display: none; }
+    .field textarea, .field input[type=text], .field input[type=number], .field input[type=url], .field select {
+      border: 1px solid #999;
+      background: #fff;
+      color: #000;
+    }
+    /* Show the currently-selected select option's text even when native truncation would clip it. */
+    .field select { -webkit-appearance: none; appearance: none; padding: 6px 8px; }
+    .step-docs { background: #f4f4f0; border-left: 2px solid #000; }
+    .step-about[open] > p { display: block; }
+    .step-about > summary { display: none; }
+    a { color: #000; text-decoration: underline; }
+    button { display: none !important; }
+  }
 </style>
 </head>
 <body>
 <header>
-  <h1>Carbon Disclosure &amp; Procurement Form</h1>
+  <h1>Carbon Credit Procurement Template</h1>
   <p>Fill in answers below. Inputs are generated from the selected framework's JSON schema and validated against it.</p>
   <div class="controls">
     <div>
@@ -295,7 +335,7 @@
       </select>
     </div>
     <div>
-      <label for="topic">Tier</label>
+      <label for="topic">Stage</label>
       <select id="topic"><option>Loading…</option></select>
     </div>
     <div>
@@ -311,7 +351,13 @@
   <div class="actions">
     <button type="button" class="primary" id="validate-btn" style="background: var(--accent); color: #fff; border: 1px solid var(--accent); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">Validate & Preview</button>
     <button type="button" id="copy-btn" style="background: #fff; border: 1px solid var(--line); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">Copy JSON</button>
+    <button type="button" id="pdf-btn" style="background: #fff; border: 1px solid var(--line); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">Download PDF</button>
     <button type="button" id="clear-btn" style="background: #fff; border: 1px solid var(--line); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">Clear</button>
+  </div>
+  <div class="stage-nav" id="stage-nav" style="display: flex; justify-content: space-between; align-items: center; margin: 8px 0 16px 0;">
+    <button type="button" id="prev-stage-btn" style="background: #fff; border: 1px solid var(--line); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">← Previous stage</button>
+    <span id="stage-indicator" style="color: var(--muted); font-size: 13px;"></span>
+    <button type="button" id="next-stage-btn" style="background: var(--accent); color: #fff; border: 1px solid var(--accent); padding: 8px 14px; border-radius: 6px; cursor: pointer; font: inherit;">Next stage →</button>
   </div>
   <pre id="result-panel">// Answers appear here after validation</pre>
 </main>
@@ -390,6 +436,7 @@ async function setFramework(doc) {
     topicSel.appendChild(el("option", { value: i }, t.label || t.name));
   });
   renderForm();
+  updateStageNav();
 }
 
 // ---------- CDOP enum resolver ----------
@@ -549,8 +596,23 @@ function renderField(field) {
     return wrap;
   }
 
-  // String with options → select
+  // String with options → select, or radio group when any option is long enough to be truncated by a native select
   if (type === "string" && hasOptions) {
+    const anyLong = field.options.some(o => (o || "").length > 60);
+    if (anyLong) {
+      const group = el("div", { class: "radio-group", "data-role": "radio-string", role: "radiogroup" });
+      const groupName = fieldId(field);
+      field.options.forEach((o, i) => {
+        const inputId = `${groupName}_${i}`;
+        const row = el("label", { class: "radio-row", for: inputId },
+          el("input", { type: "radio", id: inputId, name: groupName, value: o }),
+          el("span", { class: "radio-text" }, o),
+        );
+        group.appendChild(row);
+      });
+      wrap.appendChild(group);
+      return wrap;
+    }
     const sel = el("select", { id: fieldId(field), "data-role": "select-string" },
       el("option", { value: "" }, "— select —"),
       ...field.options.map(o => el("option", { value: o }, o)),
@@ -909,6 +971,14 @@ function readField(fEl, field) {
 
   // String with options
   if (type === "string" && hasOptions) {
+    const radioGroup = fEl.querySelector('[data-role="radio-string"]');
+    if (radioGroup) {
+      const checked = radioGroup.querySelector("input[type=radio]:checked");
+      if (!checked) return { value: undefined };
+      const v = checked.value;
+      if (!field.options.includes(v)) return { error: `"${v}" is not one of ${field.options.join(", ")}` };
+      return { value: v };
+    }
     const sel = fEl.querySelector('[data-role="select-string"]');
     const v = sel.value;
     if (v === "") return { value: undefined };
@@ -978,12 +1048,44 @@ function readField(fEl, field) {
   return { value: raw };
 }
 
+// ---------- Stage nav ----------
+function updateStageNav() {
+  const total = state.schema?.topic?.length || 0;
+  const idx = state.topicIndex;
+  const prevBtn = $("#prev-stage-btn");
+  const nextBtn = $("#next-stage-btn");
+  const indicator = $("#stage-indicator");
+  if (!total) { $("#stage-nav").style.display = "none"; return; }
+  $("#stage-nav").style.display = "flex";
+  prevBtn.disabled = idx <= 0;
+  nextBtn.disabled = idx >= total - 1;
+  prevBtn.style.opacity = prevBtn.disabled ? "0.4" : "1";
+  nextBtn.style.opacity = nextBtn.disabled ? "0.4" : "1";
+  prevBtn.style.cursor = prevBtn.disabled ? "not-allowed" : "pointer";
+  nextBtn.style.cursor = nextBtn.disabled ? "not-allowed" : "pointer";
+  const label = state.schema.topic[idx]?.label || state.schema.topic[idx]?.name || "";
+  indicator.textContent = `${label} — ${idx + 1} of ${total}`;
+}
+
+function goToStage(newIdx) {
+  const total = state.schema?.topic?.length || 0;
+  if (newIdx < 0 || newIdx >= total) return;
+  state.topicIndex = newIdx;
+  $("#topic").value = String(newIdx);
+  renderForm();
+  updateStageNav();
+  window.scrollTo({ top: 0, behavior: "smooth" });
+}
+
 // ---------- Wire up ----------
 $("#framework").addEventListener("change", (e) => loadFrameworkFromUrl(e.target.value));
 $("#topic").addEventListener("change", (e) => {
   state.topicIndex = Number(e.target.value);
   renderForm();
+  updateStageNav();
 });
+$("#prev-stage-btn").addEventListener("click", () => goToStage(state.topicIndex - 1));
+$("#next-stage-btn").addEventListener("click", () => goToStage(state.topicIndex + 1));
 $("#schema-file").addEventListener("change", async (e) => {
   const file = e.target.files[0];
   if (!file) return;
@@ -1014,6 +1116,16 @@ $("#validate-btn").addEventListener("click", () => {
     answers,
   };
   $("#result-panel").textContent = JSON.stringify(output, null, 2);
+});
+
+$("#pdf-btn").addEventListener("click", () => {
+  // Expand all <details> so their content prints, remember state to restore.
+  const detailsEls = Array.from(document.querySelectorAll("details"));
+  const wasOpen = detailsEls.map(d => d.open);
+  detailsEls.forEach(d => { d.open = true; });
+  const restore = () => detailsEls.forEach((d, i) => { d.open = wasOpen[i]; });
+  window.addEventListener("afterprint", restore, { once: true });
+  window.print();
 });
 
 $("#copy-btn").addEventListener("click", async () => {

--- a/index.html
+++ b/index.html
@@ -343,6 +343,19 @@ const el = (tag, attrs = {}, ...children) => {
   return n;
 };
 
+// Render text with markdown-style [label](url) links into a container.
+// Only http/https URLs are linkified; other bracket syntax passes through as plain text.
+const LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+function appendDescription(container, text) {
+  let last = 0;
+  for (const m of text.matchAll(LINK_RE)) {
+    if (m.index > last) container.appendChild(document.createTextNode(text.slice(last, m.index)));
+    container.appendChild(el("a", { href: m[2], target: "_blank", rel: "noopener noreferrer" }, m[1]));
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) container.appendChild(document.createTextNode(text.slice(last)));
+}
+
 const setStatus = (msg, kind = "info") => {
   const s = $("#status");
   if (!msg) { s.innerHTML = ""; return; }
@@ -380,8 +393,9 @@ async function setFramework(doc) {
 }
 
 // ---------- CDOP enum resolver ----------
-// Fields can declare options as { "$cdopRef": { "schema": "<name>", "pointer": "<json-pointer>", "appendOther": true } }.
+// Fields can declare options as { "$cdopRef": { "schema": "<name>", "pointer": "<json-pointer>", "exclude": ["<val>", …], "appendOther": true } }.
 // On load, we fetch the referenced CDOP schema from jsDelivr (cached per schema), resolve the pointer to its `enum`,
+// drop any values in `exclude` (some CDOP enums include a category header as the first value), optionally append "Other",
 // and mutate the field's options to the resolved string array. Renderer sees a plain options array either way.
 const CDOP_BASE = "https://cdn.jsdelivr.net/gh/Carbon-Data-Open-Protocol/Carbon-Data-Open-Protocol@main/json_schema";
 const cdopSchemaCache = new Map();
@@ -428,7 +442,11 @@ async function resolveCdopRefs(doc) {
       const node = resolveJsonPointer(schema, ref.pointer);
       const enumVals = node && Array.isArray(node.enum) ? node.enum : null;
       if (!enumVals) throw new Error(`no enum at ${ref.pointer}`);
-      const opts = enumVals.slice();
+      let opts = enumVals.slice();
+      if (Array.isArray(ref.exclude) && ref.exclude.length > 0) {
+        const skip = new Set(ref.exclude);
+        opts = opts.filter(v => !skip.has(v));
+      }
       if (ref.appendOther) opts.push("Other");
       parent[key] = opts;
     } catch (e) {
@@ -497,7 +515,9 @@ function renderField(field) {
   wrap.appendChild(label);
 
   if (field.description) {
-    wrap.appendChild(el("div", { class: "desc" }, field.description));
+    const descEl = el("div", { class: "desc" });
+    appendDescription(descEl, field.description);
+    wrap.appendChild(descEl);
   }
   if (type == null) {
     wrap.appendChild(el("div", { class: "desc" }, "Note: this field has no declared type in the schema. It's rendered as a text input; edit the JSON output if a different shape is needed."));
@@ -727,7 +747,11 @@ function renderTable(field, columns) {
   const headRow = el("tr");
   columns.forEach(c => {
     const th = el("th", {}, c.label || c.name);
-    if (c.description) th.appendChild(el("span", { class: "col-hint" }, c.description));
+    if (c.description) {
+      const hint = el("span", { class: "col-hint" });
+      appendDescription(hint, c.description);
+      th.appendChild(hint);
+    }
     headRow.appendChild(th);
   });
   headRow.appendChild(el("th", { style: "width: 40px;" }, ""));

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
       <select id="framework">
         <option value="releases/ccdf/2025-07-17/ccdf.json">CCDF (2025-07-17)</option>
         <option value="releases/seccdf/2025-09-05/seccdf.json">SECCDF (2025-09-05)</option>
-        <option value="releases/ccpt/2026-08-05/ccpt.json">CCPT (2026-08-05)</option>
+        <option value="releases/ccpt/2026-08-05/ccpt.json" selected>CCPT (2026-08-05)</option>
       </select>
     </div>
     <div>

--- a/index.html
+++ b/index.html
@@ -531,6 +531,79 @@ async function resolveCdopRefs(doc) {
   }));
 }
 
+// ---------- Number formatting ----------
+// Fields whose label/description imply a monetary value get a "$" prefix. Non-monetary
+// numeric fields (tonnage, years, etc.) still get comma grouping — just no currency symbol.
+const MONETARY_LABEL_RE = /\(USD\)|\(EUR\)|\(GBP\)|\bmonetary\b|\bprice\b/i;
+function isMonetaryLabel(label, description) {
+  const text = `${label || ""} ${description || ""}`;
+  return MONETARY_LABEL_RE.test(text);
+}
+
+// Strip formatting → plain JS number. Returns null on empty; NaN on unparseable.
+function parseFormattedNumber(raw) {
+  if (raw == null) return null;
+  const s = String(raw).replace(/[$,\s]/g, "").trim();
+  if (s === "") return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+// Insert comma grouping into a digit string, preserving a single optional decimal tail.
+// Empty / "." / lone "-" pass through so the user can type freely.
+function commaGroup(intStr) {
+  const neg = intStr.startsWith("-");
+  const digits = neg ? intStr.slice(1) : intStr;
+  if (!/^\d+$/.test(digits)) return intStr;
+  return (neg ? "-" : "") + digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+// Live-format an <input> with commas (and optional "$" prefix). Preserves the caret
+// position by counting significant chars (digits, decimal point, minus) rather than
+// raw character indexes — commas and "$" shift indexes but not caret intent.
+function wireNumberFormatting(input, monetary) {
+  const reformat = () => {
+    const raw = input.value;
+    const caret = input.selectionStart ?? raw.length;
+    const sigBeforeCaret = (raw.slice(0, caret).match(/[\d.\-]/g) || []).length;
+
+    let cleaned = raw.replace(/[^\d.\-]/g, "");
+    // Only one leading minus.
+    const isNeg = cleaned.startsWith("-");
+    cleaned = (isNeg ? "-" : "") + cleaned.replace(/-/g, "");
+    // Only one decimal point.
+    const dotIdx = cleaned.indexOf(".");
+    if (dotIdx !== -1) {
+      cleaned = cleaned.slice(0, dotIdx + 1) + cleaned.slice(dotIdx + 1).replace(/\./g, "");
+    }
+
+    if (cleaned === "" || cleaned === "-" || cleaned === ".") {
+      input.value = cleaned;
+      return;
+    }
+    const [intPart, decPart] = cleaned.split(".");
+    const grouped = commaGroup(intPart);
+    const formatted = (monetary ? "$" : "") + grouped + (decPart !== undefined ? "." + decPart : "");
+
+    input.value = formatted;
+
+    // Walk formatted string, advancing caret when we pass a significant char.
+    let counted = 0;
+    let newCaret = 0;
+    for (let i = 0; i < formatted.length; i++) {
+      if (counted >= sigBeforeCaret) break;
+      if (/[\d.\-]/.test(formatted[i])) counted++;
+      newCaret = i + 1;
+    }
+    if (counted < sigBeforeCaret) newCaret = formatted.length;
+    if (document.activeElement === input) {
+      input.setSelectionRange(newCaret, newCaret);
+    }
+  };
+  input.addEventListener("input", reformat);
+  input.addEventListener("blur", reformat);
+}
+
 // ---------- Rendering ----------
 function renderForm() {
   const form = $("#form");
@@ -677,9 +750,20 @@ function renderField(field) {
     return wrap;
   }
 
-  // Number → number input
+  // Number → text input with live comma grouping (and $ prefix for monetary fields)
   if (type === "number") {
-    wrap.appendChild(el("input", { type: "number", id: fieldId(field), "data-role": "number", step: "any" }));
+    const monetary = isMonetaryLabel(field.label, field.description);
+    const input = el("input", {
+      type: "text",
+      id: fieldId(field),
+      "data-role": "number-formatted",
+      "data-monetary": monetary ? "1" : "0",
+      inputmode: "decimal",
+      autocomplete: "off",
+      placeholder: monetary ? "$0" : "0",
+    });
+    wireNumberFormatting(input, monetary);
+    wrap.appendChild(input);
     return wrap;
   }
 
@@ -869,7 +953,18 @@ function renderTable(field, columns) {
         );
         cell.appendChild(s);
       } else if (c.type === "number") {
-        cell.appendChild(el("input", { type: "number", step: "any", "data-col": c.name }));
+        const monetary = isMonetaryLabel(c.label, c.description);
+        const input = el("input", {
+          type: "text",
+          "data-col": c.name,
+          "data-role": "number-formatted",
+          "data-monetary": monetary ? "1" : "0",
+          inputmode: "decimal",
+          autocomplete: "off",
+          placeholder: monetary ? "$0" : "0",
+        });
+        wireNumberFormatting(input, monetary);
+        cell.appendChild(input);
       } else if (c.type === "boolean") {
         cell.appendChild(el("input", { type: "checkbox", "data-col": c.name }));
       } else {
@@ -964,8 +1059,8 @@ function readField(fEl, field) {
           if (!c.options.includes(raw)) return { error: `Row ${rowIdx}, column "${c.label || c.name}": "${raw}" is not one of ${c.options.join(", ")}` };
           row[c.name] = raw;
         } else if (c.type === "number") {
-          const n = Number(raw);
-          if (!Number.isFinite(n)) return { error: `Row ${rowIdx}, column "${c.label || c.name}" must be a number` };
+          const n = parseFormattedNumber(raw);
+          if (n === null || !Number.isFinite(n)) return { error: `Row ${rowIdx}, column "${c.label || c.name}" must be a number` };
           row[c.name] = n;
         } else {
           row[c.name] = raw;
@@ -1047,11 +1142,11 @@ function readField(fEl, field) {
 
   // Number
   if (type === "number") {
-    const input = fEl.querySelector('[data-role="number"]');
+    const input = fEl.querySelector('[data-role="number-formatted"]') || fEl.querySelector('[data-role="number"]');
     const raw = (input.value || "").trim();
     if (raw === "") return { value: undefined };
-    const n = Number(raw);
-    if (!Number.isFinite(n)) return { error: "Must be a number." };
+    const n = parseFormattedNumber(raw);
+    if (n === null || !Number.isFinite(n)) return { error: "Must be a number (digits, optional decimal, e.g. 1500000 or 1,500,000)." };
     return { value: n };
   }
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>CCDF Form</title>
+<title>Carbon Disclosure &amp; Procurement Form</title>
 <style>
   :root {
     --bg: #f7f7f5;
@@ -283,7 +283,7 @@
 </head>
 <body>
 <header>
-  <h1>CCDF Answer Form</h1>
+  <h1>Carbon Disclosure &amp; Procurement Form</h1>
   <p>Fill in answers below. Inputs are generated from the selected framework's JSON schema and validated against it.</p>
   <div class="controls">
     <div>
@@ -316,7 +316,7 @@
   <pre id="result-panel">// Answers appear here after validation</pre>
 </main>
 
-<footer>Static form generated from the CCDF/SECCDF JSON schema. Empty fields are omitted from the output.</footer>
+<footer>Static form generated from the selected framework's JSON schema. Empty fields are omitted from the output.</footer>
 
 <script>
 "use strict";

--- a/index.html
+++ b/index.html
@@ -200,6 +200,7 @@
       <select id="framework">
         <option value="releases/ccdf/2025-07-17/ccdf.json">CCDF (2025-07-17)</option>
         <option value="releases/seccdf/2025-09-05/seccdf.json">SECCDF (2025-09-05)</option>
+        <option value="releases/ccpt/2026-08-05/ccpt.json">CCPT (2026-08-05)</option>
       </select>
     </div>
     <div>

--- a/releases/ccpt/2026-08-05/ccpt.json
+++ b/releases/ccpt/2026-08-05/ccpt.json
@@ -11,6 +11,8 @@
         {
           "name": "projectDetails",
           "label": "Project Details",
+          "relevanceAndUse": "This section provides foundational information about the project, including its classification, crediting framework, development status, ownership structure, mitigation approach, and key project dates. Buyers can use this information to assess whether a project aligns with their procurement objectives, portfolio criteria, and internal eligibility requirements. These questions are particularly useful during early-stage screening and project comparison, helping buyers understand the project's maturity, chosen standards and methodologies, anticipated credit issuance timeline, and legal ownership of generated credits. Buyers may choose to supplement this section with additional questions when evaluating projects that use novel methodologies, are in early stages of development, involve complex ownership arrangements, or require more detailed review of project activities and implementation plans.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the Project Design Document (PDD) or equivalent, a feasibility study, project or organization overview materials such as a brochure or pitch deck, the implementation plan, third-party assessments from a ratings agency or evaluation platform, and any supplementary material offering additional project application information not included elsewhere.",
           "sections": [
             {
               "name": "default",
@@ -50,11 +52,17 @@
                   "id": 4,
                   "name": "projectType",
                   "tier": 0,
-                  "type": "array",
+                  "type": "string",
                   "label": "Project type",
                   "table": null,
-                  "options": [],
-                  "description": "Select the project type. Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'project type', or 'Other'."
+                  "options": {
+                    "$cdopRef": {
+                      "schema": "Project_Approach_Details",
+                      "pointer": "/properties/project/properties/mitigation/items/properties/project_type",
+                      "appendOther": true
+                    }
+                  },
+                  "description": "Select the project type. Options auto-populated from the Carbon Data Open Protocol (CDOP) 'project_type' enumeration."
                 },
                 {
                   "id": 5,
@@ -63,18 +71,30 @@
                   "type": "string",
                   "label": "Crediting program",
                   "table": null,
-                  "options": [],
-                  "description": "Select the crediting program (standards body / registry) you have selected for your project. Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'crediting program' (43 options), or 'Other'."
+                  "options": {
+                    "$cdopRef": {
+                      "schema": "Project_Approach_Details",
+                      "pointer": "/properties/crediting_program/properties/crediting_program/items/properties/crediting_program_name",
+                      "appendOther": true
+                    }
+                  },
+                  "description": "Select the crediting program (standards body / registry) you have selected for your project. Options auto-populated from the Carbon Data Open Protocol (CDOP) 'crediting_program_name' enumeration."
                 },
                 {
                   "id": 6,
                   "name": "methodology",
                   "tier": 0,
                   "type": "array",
-                  "label": "Methodology (protocol)",
+                  "label": "Methodology",
                   "table": null,
-                  "options": [],
-                  "description": "What methodology (protocol) are you using to quantify emissions for this project? Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'methodology', or 'Other'."
+                  "options": {
+                    "$cdopRef": {
+                      "schema": "Project_Approach_Details",
+                      "pointer": "/properties/methodology/properties/versions/items/properties/methodology",
+                      "appendOther": true
+                    }
+                  },
+                  "description": "What methodology are you using to quantify emissions for this project? Options auto-populated from the Carbon Data Open Protocol (CDOP) 'methodology' enumeration."
                 },
                 {
                   "id": 7,
@@ -104,17 +124,17 @@
                   "label": "Project status",
                   "table": null,
                   "options": [
-                    "Pre-feasibility",
-                    "Under feasibility",
-                    "Completed feasibility",
-                    "Under development",
-                    "Under validation",
-                    "Validated",
-                    "Under verification",
-                    "Verified and issuing",
-                    "Transferred",
-                    "Completed",
-                    "Not Active"
+                    "Pre-feasibility — the project has a concept note in place, no feasibility study started",
+                    "Under feasibility — the project is securing financing or undergoing a feasibility study",
+                    "Completed feasibility — the project has completed the feasibility study",
+                    "Under development — listing in registry",
+                    "Under validation — the project is undergoing the validation process",
+                    "Validated — the project has been successfully validated",
+                    "Under verification — project is undergoing verification",
+                    "Verified and issuing — the project has completed verification processes and is actively issuing credits",
+                    "Transferred — the project has completed validation and verification processes with another standard and has been transferred over to the relevant standard",
+                    "Completed — project has finished issuing credits",
+                    "Not Active — the project has been marked inactive by the relevant standard"
                   ],
                   "description": "What is the project status? Aligned with CDOP recommendations, filtered for procurement-relevant options."
                 },
@@ -209,6 +229,8 @@
         {
           "name": "locationDetails",
           "label": "Location Details",
+          "relevanceAndUse": "This section captures the geographic location of the project at the regional, national, and subnational levels. Buyers can use this information to assess alignment with geographic procurement strategies, regional diversification objectives, and jurisdiction-specific requirements or preferences. Buyers may choose to request additional location-specific information when conducting more detailed due diligence, assessing jurisdictional considerations, or evaluating projects operating across multiple locations.",
+          "complementaryDocs": "Documentation commonly requested for this category may include project location or boundary data, such as GeoJSON, KML/KMZ files, zipped shapefiles, or equivalent materials; identified properties or parcels to date for phased enrollment or expansion; and internal zoning areas, such as passive versus active restoration areas, public versus private ownership areas, or land already enrolled, acquired, under negotiation, or identified.",
           "sections": [
             {
               "name": "default",
@@ -221,8 +243,13 @@
                   "type": "array",
                   "label": "Region",
                   "table": null,
-                  "options": [],
-                  "description": "In what region is your project located? Values should align with the Carbon Data Open Protocol (CDOP) 'Geographical Region' enumerated list (31 options)."
+                  "options": {
+                    "$cdopRef": {
+                      "schema": "Location_Details",
+                      "pointer": "/properties/project/properties/location/items/properties/geographical_region_name"
+                    }
+                  },
+                  "description": "In what region is your project located? Options auto-populated from the Carbon Data Open Protocol (CDOP) 'geographical_region_name' enumeration (M49)."
                 },
                 {
                   "id": 19,
@@ -231,8 +258,13 @@
                   "type": "array",
                   "label": "Country",
                   "table": null,
-                  "options": [],
-                  "description": "In what country is your project located? Values should be ISO 3166-1 alpha-3 country codes, per CDOP recommendations."
+                  "options": {
+                    "$cdopRef": {
+                      "schema": "Location_Details",
+                      "pointer": "/properties/project/properties/location/items/properties/country_code"
+                    }
+                  },
+                  "description": "In what country is your project located? Options auto-populated from the Carbon Data Open Protocol (CDOP) 'country_code' enumeration (ISO 3166-1 alpha-3)."
                 },
                 {
                   "id": 20,
@@ -251,6 +283,8 @@
         {
           "name": "teamPartners",
           "label": "Project Team & Partners",
+          "relevanceAndUse": "This section captures information about the organizations responsible for developing, implementing, financing, owning, and supporting the project. Buyers can use this information to understand the roles, relationships, and capabilities of the entities involved in project delivery. These questions are particularly useful for assessing organizational capacity, governance, execution risk, and the experience of key project participants in carbon markets and relevant sectors. Buyers may choose to request additional information when evaluating project developers they are working with for the first time, complex project structures involving multiple entities, or projects that require heightened commercial, operational, or legal due diligence.",
+          "complementaryDocs": "Documentation commonly requested for this category may include materials identifying the project developer, supplier, implementing partners, investors, intermediaries, validators, verifiers, registries, or other entities involved in project delivery.",
           "sections": [
             {
               "name": "default",
@@ -261,9 +295,12 @@
                   "name": "isLeadProponent",
                   "tier": 0,
                   "type": "string",
-                  "label": "Submitting organization is the lead project proponent and offtake counterparty",
+                  "label": "Submitting organization",
                   "table": null,
-                  "options": ["Yes", "No"],
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
                   "description": "Is the submitting organization the lead project proponent and the counterparty that would be signing an offtake contract?"
                 },
                 {
@@ -357,8 +394,13 @@
                           "name": "countryOfRegistration",
                           "type": "string",
                           "label": "Country of legal registration",
-                          "options": null,
-                          "description": "ISO 3166-1 alpha-3 country code, per CDOP."
+                          "options": {
+                            "$cdopRef": {
+                              "schema": "Location_Details",
+                              "pointer": "/properties/project/properties/location/items/properties/country_code"
+                            }
+                          },
+                          "description": "ISO 3166-1 alpha-3 country code, auto-populated from CDOP."
                         },
                         {
                           "name": "website",
@@ -427,24 +469,42 @@
                         },
                         {
                           "name": "projectTypes",
-                          "type": "string",
+                          "type": "array",
                           "label": "Project types",
-                          "options": null,
-                          "description": "Comma-separated. Values should align with CDOP 'project type' enumerated list, or 'Other'."
+                          "options": {
+                            "$cdopRef": {
+                              "schema": "Project_Approach_Details",
+                              "pointer": "/properties/project/properties/mitigation/items/properties/project_type",
+                              "appendOther": true
+                            }
+                          },
+                          "description": "Auto-populated from CDOP 'project_type'."
                         },
                         {
                           "name": "registries",
-                          "type": "string",
+                          "type": "array",
                           "label": "Associated registries",
-                          "options": null,
-                          "description": "Comma-separated. Values should align with CDOP 'registry' enumerated list, or 'Other'."
+                          "options": {
+                            "$cdopRef": {
+                              "schema": "Project_Approach_Details",
+                              "pointer": "/properties/registry/properties/current_registry",
+                              "appendOther": true
+                            }
+                          },
+                          "description": "Auto-populated from CDOP 'current_registry'."
                         },
                         {
                           "name": "countries",
-                          "type": "string",
+                          "type": "array",
                           "label": "Project countries",
-                          "options": null,
-                          "description": "Comma-separated. Values should align with CDOP 'Country Name English Short Name' enumerated list, or 'Other'."
+                          "options": {
+                            "$cdopRef": {
+                              "schema": "Location_Details",
+                              "pointer": "/properties/project/properties/location/items/properties/country_name",
+                              "appendOther": true
+                            }
+                          },
+                          "description": "Auto-populated from CDOP 'country_name' (English short name)."
                         },
                         {
                           "name": "links",
@@ -472,6 +532,8 @@
         {
           "name": "legalReputational",
           "label": "Legal & Reputational Disclosure",
+          "relevanceAndUse": "This section provides information on the legal standing, organizational history, and reputational risk profile of the entities responsible for developing and implementing the project. It includes disclosures related to ownership structure, legal and regulatory matters, prior contractual performance, financial distress, and any publicly reported issues that may be relevant to project execution, stakeholder confidence, or the long-term viability of the project. Buyers can use this information to assess potential risks associated with the organizations involved in the project's development and implementation. These questions are particularly useful for supporting counterparty due diligence, procurement partnerships, and evaluations of alignment with organizational policies and risk tolerance. Depending on the project's characteristics and whether the developer and implementing bodies are well-established, buyers may choose to supplement this section with additional legal, compliance, human rights, anti-corruption, or sanction-related due diligence.",
+          "complementaryDocs": "Documentation commonly requested for this category may include permits or regulatory approvals, business licenses, external project risk assessments, and risk assessments or risk tools completed as part of validation by a carbon credit standards body.",
           "sections": [
             {
               "name": "default",
@@ -484,7 +546,11 @@
                   "type": "string",
                   "label": "Active or threatened legal actions",
                   "table": null,
-                  "options": ["Yes", "No", "Not Applicable"],
+                  "options": [
+                    "Yes",
+                    "No",
+                    "Not Applicable"
+                  ],
                   "description": "Are there any active or threatened actions, litigations, investigations or convictions against the project owners, project developers, shareholders, or members of the project management team? These investigations could be related to corruption, forced labor, gender-based violence/harassment, or other non-compliance with financial, social, or environmental regulations, impacts to local/indigenous communities, or any other matter that could be reasonably expected to negatively impact your entity or the project's reputation."
                 },
                 {
@@ -502,9 +568,12 @@
                   "name": "terminatedForNonPerformance",
                   "tier": 0,
                   "type": "string",
-                  "label": "Ever terminated for non-performance on a contract",
+                  "label": "Performance history",
                   "table": null,
-                  "options": ["Yes", "No"],
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
                   "description": "Has the project developer or affiliated implementation partners ever been terminated for non-performance on a contract?"
                 },
                 {
@@ -512,9 +581,12 @@
                   "name": "bankruptcy",
                   "tier": 0,
                   "type": "string",
-                  "label": "Ever filed or petitioned for bankruptcy",
+                  "label": "Bankruptcy",
                   "table": null,
-                  "options": ["Yes", "No"],
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
                   "description": "Has the project developer or affiliated implementation partners ever filed or petitioned for bankruptcy?"
                 },
                 {
@@ -534,6 +606,8 @@
         {
           "name": "landTenure",
           "label": "Land Tenure & Ownership",
+          "relevanceAndUse": "This section provides information on the project's land tenure arrangements, carbon rights, land access strategy, and permitting status. It includes details on the ownership and control of project lands, the legal basis for land and carbon rights, contractual arrangements with landowners or land users, and the permissions required to develop, operate, and scale the project. It also includes information on local communities and Indigenous Peoples and Local Communities (IPLCs) and the accompanying status of Free, Prior, and Informed Consent (FPIC). Buyers can use this information to assess the security and durability of the project's land and carbon rights, identify potential risks related to land tenure, ownership disputes, or permitting requirements, and evaluate the project's readiness for implementation and long-term operation. These questions are particularly relevant for projects that rely on long-term access to land or natural resources. Buyers may choose to supplement this section with additional due diligence where projects operate across complex land tenure systems, involve customary or Indigenous land rights, or depend on large numbers of participating landowners or land users.",
+          "complementaryDocs": "Documentation commonly requested for this category may include land management plans, land rights documentation, property ownership records, concessions, easements, leases, use rights, carbon rights contracts, title documentation, or materials demonstrating legal control of project areas.",
           "sections": [
             {
               "name": "default",
@@ -584,7 +658,11 @@
                   "type": "string",
                   "label": "Land ownership granted by competent authority",
                   "table": null,
-                  "options": ["Yes", "No", "Not Applicable"],
+                  "options": [
+                    "Yes",
+                    "No",
+                    "Not Applicable"
+                  ],
                   "description": "Can you confirm that all the land ownership associated with the project is granted under statute, regulation, or decree by a competent authority of the country in which your project is being developed?"
                 },
                 {
@@ -602,7 +680,7 @@
                   "name": "indigenousCommunitiesEngagement",
                   "tier": 0,
                   "type": "string",
-                  "label": "Indigenous communities engagement (UNDRIP, ILO 169)",
+                  "label": "Indigenous communities",
                   "table": null,
                   "options": [],
                   "description": "If Indigenous communities are impacted by the project, describe which communities and their location relative to the project, and explain what steps the project has taken to conform with the UN Declaration on the Rights of Indigenous Peoples and ILO's Convention 169 on Indigenous and Tribal Peoples. If no Indigenous communities are impacted or involved in the project, indicate N/A. (≤500 words)"
@@ -614,7 +692,11 @@
                   "type": "string",
                   "label": "Written FPIC agreements in place",
                   "table": null,
-                  "options": ["Yes", "No", "Not Applicable"],
+                  "options": [
+                    "Yes",
+                    "No",
+                    "Not Applicable"
+                  ],
                   "description": "Do you have written agreements in place in which participating indigenous peoples and local communities (IPLCs) give free, prior and informed consent (FPIC) for their enrollment in the project?"
                 }
               ]
@@ -624,6 +706,8 @@
         {
           "name": "socioEnvironmental",
           "label": "Socio-Environmental Impacts & Indicators",
+          "relevanceAndUse": "This section provides information on the project's socio-environmental context, anticipated impacts, and approach to identifying, monitoring, and managing risks and outcomes. It includes information around stakeholder mapping details, social and environmental risk assessments, impact monitoring frameworks, grievance mechanisms, ecosystem characteristics, climate-related vulnerabilities, resource use, waste management, and other environmental safeguards. It also seeks information on the project's alignment with broader sustainable development objectives, including the Sustainable Development Goals (SDGs). Buyers can use this information to assess how the project identifies and manages potential social and environmental risks, contributes to positive outcomes beyond carbon, and monitors its impacts over time. These questions are particularly relevant for projects that interact directly with local communities, natural ecosystems, or shared resources, including nature-based, agriculture, forestry, blue carbon, and other land-use projects — but have been emphasized across projects by leading buyers. Depending on the project's scale, geography, and risk profile, buyers may choose to supplement this section with additional due diligence related to biodiversity, human rights, environmental and social safeguards, climate resilience, resource use, or community impacts.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the stakeholder and community engagement plan, stakeholder engagement documentation, documentation of stakeholder consultation processes with beneficiaries including FPIC where applicable, supporting materials such as beneficiary agreements, summaries, consultation outcomes, or evidence of consent, and any social and environmental impact assessments or ESG reports.",
           "sections": [
             {
               "name": "default",
@@ -654,7 +738,7 @@
                   "name": "localRisksAndMitigation",
                   "tier": 0,
                   "type": "string",
-                  "label": "Local social or environmental risks and mitigation",
+                  "label": "Social/environmental risks and mitigation",
                   "table": null,
                   "options": [],
                   "description": "Describe any local social or environmental risks the project faces. For each identified risk, describe potential impacts on the identified groups above and outline mitigation strategies you would take to reduce or manage the risk. Examples of risks include altering stakeholders' rights to food, housing, education, etc., perpetuating unequal power dynamics, habitat fragmentation due to project infrastructure, changes to water flow or quality, changes to soil conditions, or other attributes surfaced by the project's risk assessment process. (≤200 words)"
@@ -713,7 +797,7 @@
                   "name": "grievanceProcedure",
                   "tier": 0,
                   "type": "string",
-                  "label": "Grievance procedure and reported grievances",
+                  "label": "Grievance mechanism",
                   "table": null,
                   "options": [],
                   "description": "Does the project have a procedure or policy to address disputes or grievances? If so, detail your procedure and any grievances reported to date. (≤200 words)"
@@ -733,7 +817,7 @@
                   "name": "resourceNeeds",
                   "tier": 0,
                   "type": "string",
-                  "label": "Water/land/energy/other natural resource needs",
+                  "label": "Natural resource needs",
                   "table": null,
                   "options": [],
                   "description": "Describe the water/land/energy/other natural resource needs of the project in the first few years, and describe how these resource needs may evolve in the coming decade. Example descriptions may include kWh, gallons of water, or hectares per ton of carbon sequestered, depending on the type of project. (≤500 words)"
@@ -761,6 +845,8 @@
         {
           "name": "projectFinancials",
           "label": "Project Financials",
+          "relevanceAndUse": "This section provides information on the project's financial structure, funding sources, revenue model, and commercial development status. It includes disclosures related to project financing, sources of capital, additional revenue streams beyond carbon credits, de-risking instruments, offtake agreements, key development and financing milestones, and the project's overall financial position. Buyers can use this information to assess the project's financial viability, funding maturity, and ability to achieve planned implementation and credit delivery objectives. These questions are particularly useful for understanding the extent to which a project depends on carbon credit revenues, the diversity and stability of its funding sources, and the financial risks that could affect project execution, scalability, or long-term operation. While relevant across project types, this section may be especially valuable for capital-intensive projects, early-stage developments, first-of-a-kind technologies, and projects seeking substantial upfront investment prior to credit issuance. Depending on the project's financing structure and stage of development, buyers may choose to supplement this section with additional financial, commercial, or investment due diligence depending on their risk tolerances.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the project's financial model and budget, including information on project revenue sources, major cost sources, financing structure, financial viability, and carbon revenue dependence.",
           "sections": [
             {
               "name": "default",
@@ -801,10 +887,10 @@
                         },
                         {
                           "name": "estimatedContribution",
-                          "type": "number",
-                          "label": "Estimated contribution to project finances",
+                          "type": "string",
+                          "label": "Estimated contribution to project finances (USD)",
                           "options": null,
-                          "description": "Numeric — e.g. % share or USD."
+                          "description": "USD value or N/A."
                         }
                       ]
                     }
@@ -848,7 +934,13 @@
                           "name": "type",
                           "type": "string",
                           "label": "Type",
-                          "options": ["Grant", "Equity", "Loan", "Debt", "Other"],
+                          "options": [
+                            "Grant",
+                            "Equity",
+                            "Loan",
+                            "Debt",
+                            "Other"
+                          ],
                           "description": null
                         },
                         {
@@ -862,7 +954,12 @@
                           "name": "status",
                           "type": "string",
                           "label": "Status",
-                          "options": ["Secured", "Identified", "In Discussion", "Not Secured"],
+                          "options": [
+                            "Secured",
+                            "Identified",
+                            "In Discussion",
+                            "Not Secured"
+                          ],
                           "description": null
                         },
                         {
@@ -933,7 +1030,7 @@
                   "name": "fortuneBuyers",
                   "tier": 0,
                   "type": "string",
-                  "label": "Fortune 100/500 buyers",
+                  "label": "Buyers",
                   "table": null,
                   "options": [],
                   "description": "How many credit buyers do you have that are Fortune 100 or Fortune 500 companies, and in which business sectors? (≤20 words)"
@@ -945,6 +1042,8 @@
         {
           "name": "commercialOffer",
           "label": "Commercial Offer",
+          "relevanceAndUse": "This section provides information on the credits being offered under this proposal, including available volumes, pricing, delivery timing, and key commercial considerations. It also includes information on potential future project expansion, cost uncertainty, and any factors that could affect buyer access to the offered credits. Buyers can use this information to evaluate the commercial attractiveness of the offer, compare proposals, and assess potential pricing, supply, and delivery risks. These questions are particularly useful during procurement, contracting, and portfolio construction stages.",
+          "complementaryDocs": "Documentation commonly requested for this category may include materials related to credit volume projections, delivery schedule, and offtake terms.",
           "sections": [
             {
               "name": "default",
@@ -965,12 +1064,59 @@
                           "type": "string",
                           "label": "Vintage year",
                           "options": [
-                            "2008","2009","2010","2011","2012","2013","2014","2015","2016","2017",
-                            "2018","2019","2020","2021","2022","2023","2024","2025","2026","2027",
-                            "2028","2029","2030","2031","2032","2033","2034","2035","2036","2037",
-                            "2038","2039","2040","2041","2042","2043","2044","2045","2046","2047",
-                            "2048","2049","2050","2051","2052","2053","2054","2055","2056","2057",
-                            "2058","2059","2060"
+                            "2008",
+                            "2009",
+                            "2010",
+                            "2011",
+                            "2012",
+                            "2013",
+                            "2014",
+                            "2015",
+                            "2016",
+                            "2017",
+                            "2018",
+                            "2019",
+                            "2020",
+                            "2021",
+                            "2022",
+                            "2023",
+                            "2024",
+                            "2025",
+                            "2026",
+                            "2027",
+                            "2028",
+                            "2029",
+                            "2030",
+                            "2031",
+                            "2032",
+                            "2033",
+                            "2034",
+                            "2035",
+                            "2036",
+                            "2037",
+                            "2038",
+                            "2039",
+                            "2040",
+                            "2041",
+                            "2042",
+                            "2043",
+                            "2044",
+                            "2045",
+                            "2046",
+                            "2047",
+                            "2048",
+                            "2049",
+                            "2050",
+                            "2051",
+                            "2052",
+                            "2053",
+                            "2054",
+                            "2055",
+                            "2056",
+                            "2057",
+                            "2058",
+                            "2059",
+                            "2060"
                           ],
                           "description": null
                         },
@@ -979,12 +1125,59 @@
                           "type": "string",
                           "label": "Delivery year",
                           "options": [
-                            "2008","2009","2010","2011","2012","2013","2014","2015","2016","2017",
-                            "2018","2019","2020","2021","2022","2023","2024","2025","2026","2027",
-                            "2028","2029","2030","2031","2032","2033","2034","2035","2036","2037",
-                            "2038","2039","2040","2041","2042","2043","2044","2045","2046","2047",
-                            "2048","2049","2050","2051","2052","2053","2054","2055","2056","2057",
-                            "2058","2059","2060"
+                            "2008",
+                            "2009",
+                            "2010",
+                            "2011",
+                            "2012",
+                            "2013",
+                            "2014",
+                            "2015",
+                            "2016",
+                            "2017",
+                            "2018",
+                            "2019",
+                            "2020",
+                            "2021",
+                            "2022",
+                            "2023",
+                            "2024",
+                            "2025",
+                            "2026",
+                            "2027",
+                            "2028",
+                            "2029",
+                            "2030",
+                            "2031",
+                            "2032",
+                            "2033",
+                            "2034",
+                            "2035",
+                            "2036",
+                            "2037",
+                            "2038",
+                            "2039",
+                            "2040",
+                            "2041",
+                            "2042",
+                            "2043",
+                            "2044",
+                            "2045",
+                            "2046",
+                            "2047",
+                            "2048",
+                            "2049",
+                            "2050",
+                            "2051",
+                            "2052",
+                            "2053",
+                            "2054",
+                            "2055",
+                            "2056",
+                            "2057",
+                            "2058",
+                            "2059",
+                            "2060"
                           ],
                           "description": null
                         },
@@ -1037,7 +1230,7 @@
                   "name": "buyerSeniority",
                   "tier": 0,
                   "type": "string",
-                  "label": "Buyer seniority applicable to offered credits",
+                  "label": "Buyer seniority",
                   "table": null,
                   "options": [],
                   "description": "Are credits that are indicated in the offer potentially subject to buyer seniority? (≤20 words)"
@@ -1049,6 +1242,8 @@
         {
           "name": "beneficiaries",
           "label": "Beneficiaries & Benefit Sharing",
+          "relevanceAndUse": "This section provides information on the project's benefit sharing approach, including the contributions expected from beneficiaries, the monetary and non-monetary benefits they are expected to receive, how carbon credit revenues are allocated, and how the benefit sharing plan was developed. Buyers can use this information to assess whether benefits are distributed in a transparent, equitable, and verifiable manner, and to understand how the project engages with affected communities or other stakeholders. These questions are particularly relevant for projects with community-based participation, shared revenue arrangements, or requirements to distribute proceeds to landowners, land users, local communities, or government entities. Buyers may choose to supplement this section with additional due diligence where benefit sharing arrangements are complex, material to project viability, or subject to evolving legal or policy frameworks.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the benefits sharing plan or agreement as well as proof of distributed payments (via electronic payments, transfer receipts, etc.) and example contracts between the landowners (or tenants) that outline the obligations of participating in the project or program.",
           "sections": [
             {
               "name": "default",
@@ -1213,6 +1408,8 @@
         {
           "name": "additionality",
           "label": "Additionality",
+          "relevanceAndUse": "This section provides information on the project's additionality, policy context, and reliance on carbon finance. Buyers can use this information to assess the credibility of the project's additionality claims, the role of carbon revenue in supporting project viability, and any policy, regulatory, or accounting considerations that may affect credit eligibility, use, or claims. These questions are particularly useful for evaluating whether the project depends on carbon finance, whether other revenue streams or public support may affect additionality, and whether the project is aligned with relevant national climate policies, carbon market frameworks, or Article 6-related requirements. Depending on the project's characteristics, jurisdictional context, intended credit use, and applicable standard or methodology, buyers may choose to supplement this section with additional review of financial additionality, regulatory surplus, host country authorization, corresponding adjustments, baseline assumptions, or evolving carbon market rules.",
+          "complementaryDocs": "Documentation commonly requested for this category includes the additionality assessment and any accompanying additionality tests set forth by the methodology.",
           "sections": [
             {
               "name": "default",
@@ -1277,7 +1474,12 @@
                   "type": "string",
                   "label": "Corresponding adjustments expected",
                   "table": null,
-                  "options": ["Yes", "No", "Not yet determined", "Not applicable"],
+                  "options": [
+                    "Yes",
+                    "No",
+                    "Not yet determined",
+                    "Not applicable"
+                  ],
                   "description": "Are corresponding adjustments expected or necessary?"
                 },
                 {
@@ -1307,6 +1509,8 @@
         {
           "name": "durability",
           "label": "Durability & Permanence",
+          "relevanceAndUse": "This section provides information on the project's durability and permanence profile, including the risks that could affect the continued storage or mitigation of credited emissions over time. Buyers can use this information to assess the likelihood that credited climate benefits will persist over the claimed durability period and to understand how the project allocates responsibility for potential reversals. Depending on the project's activity type, storage pathway, guarantee term, methodology, and risk profile, buyers may choose to supplement this section with additional review of reversal modeling, monitoring plans, insurance arrangements, legal protections, land tenure or use restrictions, buffer pool adequacy, or long-term stewardship obligations.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the non-permanence assessment and assumptions, durability/reversal risk analysis, required buffer pool contributions, insurance offerings, or other contingencies as set by the methodology and/or standard.",
           "sections": [
             {
               "name": "default",
@@ -1369,6 +1573,8 @@
         {
           "name": "quantificationUncertainty",
           "label": "Quantification Uncertainty",
+          "relevanceAndUse": "This section provides information on how the project quantifies emissions reductions or removals and how uncertainty is assessed. It includes disclosures related to the project's quantification approach, sources of uncertainty, uncertainty level, and use of pilot or locally collected data to validate estimated outcomes. Buyers can use this information to assess the reliability and conservativeness of the project's credited climate benefits. These questions are especially relevant for projects that rely on modeling, emission factors, remote sensing, biological growth rates, soil or biomass measurements, technology performance assumptions, or site-specific operating data. Depending on the project type and methodology, buyers may choose to supplement this section with additional review of model inputs, measurement protocols, sampling design, uncertainty deductions, or sensitivity analyses.",
+          "complementaryDocs": "Documentation commonly requested for this category may include baseline data and assumptions, ex-ante credit projections and underlying assumptions / allometric equations, baselining data and procedures, carbon removal/emissions projections, a third-party life cycle assessment (LCA) or completed lifecycle emissions intake form (LEIF), and any additional documents for the selected methodology, including supporting calculations and model documentation.",
           "sections": [
             {
               "name": "default",
@@ -1418,7 +1624,10 @@
                   "type": "string",
                   "label": "Pilot or locally collected data used to validate estimates",
                   "table": null,
-                  "options": ["Yes", "No"],
+                  "options": [
+                    "Yes",
+                    "No"
+                  ],
                   "description": "Has the project used pilot and/or locally collected data to validate the estimated project emissions or removals?"
                 }
               ]
@@ -1428,6 +1637,8 @@
         {
           "name": "leakage",
           "label": "Leakage",
+          "relevanceAndUse": "This section provides information on the project's leakage risks and how they are assessed, managed, and accounted for. Buyers can use this information to assess whether credited emissions reductions or removals could be offset by emissions increases or negative impacts elsewhere. These questions are especially relevant for projects involving biomass, waste streams, land use, avoided conversion, fuel switching, agricultural production, or other activities that may shift demand, supply, land use, or emissions outside the project boundary. Depending on the project type and methodology, buyers may choose to supplement this section with additional review of leakage assumptions, market effects, supply chain impacts, monitoring plans, or supporting scientific literature.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the leakage assessment and assumptions, usually outlined by the chosen methodology.",
           "sections": [
             {
               "name": "default",
@@ -1470,6 +1681,8 @@
         {
           "name": "mrv",
           "label": "MRV",
+          "relevanceAndUse": "This section provides information on the project's monitoring, measurement, reporting, and verification approach, including any MMRV practices that exceed methodology requirements. It includes disclosures related to enhanced monitoring plans, post-crediting monitoring duration, monitoring cadence, and how the project plans to track outcomes over time. This section will have throughlines with questions related to Quantification Uncertainty, as both are primarily defined by the chosen methodology. Buyers can use this information to assess the strength, transparency, and durability of the project's evidence base. Depending on the project type, methodology, and risk profile, buyers may choose to supplement this section with additional review of monitoring technologies, data collection protocols, reporting cadence, verification procedures, data transparency, or post-crediting oversight.",
+          "complementaryDocs": "Documentation commonly requested for this category may include the monitoring, measurement, reporting, and verification (MMRV) plan, as outlined by the methodology, and any accompanying validation/verification reports.",
           "sections": [
             {
               "name": "default",

--- a/releases/ccpt/2026-08-05/ccpt.json
+++ b/releases/ccpt/2026-08-05/ccpt.json
@@ -59,6 +59,7 @@
                     "$cdopRef": {
                       "schema": "Project_Approach_Details",
                       "pointer": "/properties/project/properties/mitigation/items/properties/project_type",
+                      "exclude": ["UNFCCC Article 6.2 common nomenclatures (Activity Type)"],
                       "appendOther": true
                     }
                   },
@@ -274,7 +275,7 @@
                   "label": "Country subdivision (state/province)",
                   "table": null,
                   "options": [],
-                  "description": "In which country subdivision (state/province) is your project located? Values should be ISO 3166-2 country subdivision codes, per CDOP recommendations."
+                  "description": "In which country subdivision (state/province) is your project located? If available, please list locations in ISO 3166-2 country subdivision codes, per CDOP recommendations."
                 }
               ]
             }
@@ -475,6 +476,7 @@
                             "$cdopRef": {
                               "schema": "Project_Approach_Details",
                               "pointer": "/properties/project/properties/mitigation/items/properties/project_type",
+                              "exclude": ["UNFCCC Article 6.2 common nomenclatures (Activity Type)"],
                               "appendOther": true
                             }
                           },
@@ -810,7 +812,7 @@
                   "label": "IUCN ecoregion(s) or ecosystem(s)",
                   "table": null,
                   "options": [],
-                  "description": "Using the IUCN's Global Ecosystem Typology, list the ecoregion(s) or ecosystem(s) the project is located in. (≤50 words)"
+                  "description": "Using the [IUCN's Global Ecosystem Typology](https://global-ecosystems.org/), list the ecoregion(s) or ecosystem(s) the project is located in. (≤50 words)"
                 },
                 {
                   "id": 46,

--- a/releases/ccpt/2026-08-05/ccpt.json
+++ b/releases/ccpt/2026-08-05/ccpt.json
@@ -1,0 +1,1505 @@
+{
+  "$framework": "https://github.com/RMI/ccdf/blob/main/releases/ccpt/2026-08-05/ccpt.json",
+  "version": "1.0.0",
+  "name": "ccpt",
+  "title": "Carbon Credit Procurement Template",
+  "topic": [
+    {
+      "name": "stage1",
+      "label": "Stage 1: Screening & Fit",
+      "steps": [
+        {
+          "name": "projectDetails",
+          "label": "Project Details",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 1,
+                  "name": "projectName",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project name",
+                  "table": null,
+                  "options": [],
+                  "description": "What is the name of your project? (≤10 words)"
+                },
+                {
+                  "id": 2,
+                  "name": "registryId",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Registry ID",
+                  "table": null,
+                  "options": [],
+                  "description": "If applicable, provide your registry ID (e.g. VCS1234 or GS12345)."
+                },
+                {
+                  "id": 3,
+                  "name": "registryUrl",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Registry URL",
+                  "table": null,
+                  "options": [],
+                  "description": "If applicable, provide the URL link to your project's website on the registry."
+                },
+                {
+                  "id": 4,
+                  "name": "projectType",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Project type",
+                  "table": null,
+                  "options": [],
+                  "description": "Select the project type. Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'project type', or 'Other'."
+                },
+                {
+                  "id": 5,
+                  "name": "creditingProgram",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Crediting program",
+                  "table": null,
+                  "options": [],
+                  "description": "Select the crediting program (standards body / registry) you have selected for your project. Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'crediting program' (43 options), or 'Other'."
+                },
+                {
+                  "id": 6,
+                  "name": "methodology",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Methodology (protocol)",
+                  "table": null,
+                  "options": [],
+                  "description": "What methodology (protocol) are you using to quantify emissions for this project? Values should align with the Carbon Data Open Protocol (CDOP) enumerated list for 'methodology', or 'Other'."
+                },
+                {
+                  "id": 7,
+                  "name": "methodologyVersion",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Methodology version",
+                  "table": null,
+                  "options": [],
+                  "description": "What version of the methodology is being used to quantify emissions for this project? (≤10 words)"
+                },
+                {
+                  "id": 8,
+                  "name": "methodologyUrl",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Methodology URL",
+                  "table": null,
+                  "options": [],
+                  "description": "If available, provide a URL link to the selected methodology."
+                },
+                {
+                  "id": 9,
+                  "name": "projectStatus",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project status",
+                  "table": null,
+                  "options": [
+                    "Pre-feasibility",
+                    "Under feasibility",
+                    "Completed feasibility",
+                    "Under development",
+                    "Under validation",
+                    "Validated",
+                    "Under verification",
+                    "Verified and issuing",
+                    "Transferred",
+                    "Completed",
+                    "Not Active"
+                  ],
+                  "description": "What is the project status? Aligned with CDOP recommendations, filtered for procurement-relevant options."
+                },
+                {
+                  "id": 10,
+                  "name": "mitigationOutcome",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Mitigation outcome",
+                  "table": null,
+                  "options": [
+                    "Removal",
+                    "Reduction/Avoidance",
+                    "Mixed (removals and reduction/avoidance)"
+                  ],
+                  "description": "What mitigation outcome does this project support?"
+                },
+                {
+                  "id": 11,
+                  "name": "projectDescription",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project description",
+                  "table": null,
+                  "options": [],
+                  "description": "Provide a description of the project. Include an overview of the project's activities and theory of change. (≤200 words)"
+                },
+                {
+                  "id": 12,
+                  "name": "projectStartDate",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project start date",
+                  "table": null,
+                  "options": [],
+                  "description": "Format: MM/YYYY (e.g. 06/2025)."
+                },
+                {
+                  "id": 13,
+                  "name": "creditingPeriodStartDate",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Crediting period start date",
+                  "table": null,
+                  "options": [],
+                  "description": "Format: MM/YYYY (e.g. 06/2025)."
+                },
+                {
+                  "id": 14,
+                  "name": "creditingPeriodEndDate",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Crediting period end date",
+                  "table": null,
+                  "options": [],
+                  "description": "Format: MM/YYYY (e.g. 06/2025)."
+                },
+                {
+                  "id": 15,
+                  "name": "dateEstimationNotes",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Date estimation notes",
+                  "table": null,
+                  "options": [],
+                  "description": "Indicate if any of the dates above are an estimation and give additional context. (≤50 words)"
+                },
+                {
+                  "id": 16,
+                  "name": "technologyDifferentiation",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Technology or approach differentiation",
+                  "table": null,
+                  "options": [],
+                  "description": "How does the technology/approach used in this project differ from other climate solutions? This may include patents, patent applications, proprietary know-how, exclusive data, specialized expertise, or other aspects. (≤100 words)"
+                },
+                {
+                  "id": 17,
+                  "name": "additionalCertifications",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Alignment with additional certifications, labels, or initiatives",
+                  "table": null,
+                  "options": [],
+                  "description": "Is the project, methodology, or chosen standard aligned with any additional certifications, market labels, or initiatives (e.g. Verra ABACUS, CCP, Forest Stewardship Council, Biodiversity Standards, W+ or similar)? If yes, describe the status and level of alignment. (≤100 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "locationDetails",
+          "label": "Location Details",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 18,
+                  "name": "region",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Region",
+                  "table": null,
+                  "options": [],
+                  "description": "In what region is your project located? Values should align with the Carbon Data Open Protocol (CDOP) 'Geographical Region' enumerated list (31 options)."
+                },
+                {
+                  "id": 19,
+                  "name": "country",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Country",
+                  "table": null,
+                  "options": [],
+                  "description": "In what country is your project located? Values should be ISO 3166-1 alpha-3 country codes, per CDOP recommendations."
+                },
+                {
+                  "id": 20,
+                  "name": "subdivision",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Country subdivision (state/province)",
+                  "table": null,
+                  "options": [],
+                  "description": "In which country subdivision (state/province) is your project located? Values should be ISO 3166-2 country subdivision codes, per CDOP recommendations."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "teamPartners",
+          "label": "Project Team & Partners",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 21,
+                  "name": "isLeadProponent",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Submitting organization is the lead project proponent and offtake counterparty",
+                  "table": null,
+                  "options": ["Yes", "No"],
+                  "description": "Is the submitting organization the lead project proponent and the counterparty that would be signing an offtake contract?"
+                },
+                {
+                  "id": 22,
+                  "name": "creditOwnershipEntity",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Legal owner of credits",
+                  "table": null,
+                  "options": [],
+                  "description": "What entity will have legal ownership of the credits produced by the project? Describe the relationship between the project developer and this entity as applicable. (≤50 words)"
+                },
+                {
+                  "id": 23,
+                  "name": "developerCoreBusiness",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project developer core business",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe the project developer's core business or activity, product, or service offering. Include any relevant project development experience, emissions reduction targets, clean energy targets, and/or any relevant R&D focus. (≤200 words)"
+                },
+                {
+                  "id": 24,
+                  "name": "keyOrganizations",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Key organizations",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "role",
+                          "type": "string",
+                          "label": "Key Organization Role",
+                          "options": [
+                            "Project developer",
+                            "Register/accounting and tracking registry",
+                            "Registry with Transaction Functionality",
+                            "Infrastructure providers/operators",
+                            "Government",
+                            "Multilateral Organizations",
+                            "Carbon Crediting Program/Standard Setters",
+                            "Verification Accreditation Agency",
+                            "Project owner",
+                            "Project implementer",
+                            "Technical consultant",
+                            "GIS Advisory",
+                            "Feasibility study service",
+                            "Technical document service",
+                            "Administrative service",
+                            "Biodiversity advisory",
+                            "Political advocacy",
+                            "MRV data provider",
+                            "Credit distribution partner",
+                            "Philanthropic funder",
+                            "Equity investor",
+                            "Lender",
+                            "Carbon streamer/pre-purchaser",
+                            "Offtaker",
+                            "Insurance provider",
+                            "Guarantee provider",
+                            "Public sector financier",
+                            "Other"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "legalName",
+                          "type": "string",
+                          "label": "Legal name of organization",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "legalType",
+                          "type": "string",
+                          "label": "Legal type of organization",
+                          "options": [
+                            "For-profit",
+                            "Global Non-Profit",
+                            "Local Non-Profit",
+                            "Government",
+                            "University or academic institution",
+                            "Other"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "countryOfRegistration",
+                          "type": "string",
+                          "label": "Country of legal registration",
+                          "options": null,
+                          "description": "ISO 3166-1 alpha-3 country code, per CDOP."
+                        },
+                        {
+                          "name": "website",
+                          "type": "string",
+                          "label": "Organization website",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "contactName",
+                          "type": "string",
+                          "label": "Primary contact name",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "contactEmail",
+                          "type": "string",
+                          "label": "Primary contact email",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "yearsInOperation",
+                          "type": "number",
+                          "label": "Years in operation",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "contractualRelationship",
+                          "type": "string",
+                          "label": "Contractual relationship with project",
+                          "options": null,
+                          "description": "≤50 words"
+                        },
+                        {
+                          "name": "relevantExperience",
+                          "type": "string",
+                          "label": "Relevant experience material to project",
+                          "options": null,
+                          "description": "≤50 words"
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Give identifying information for the organizations involved in this project. Add rows as necessary."
+                },
+                {
+                  "id": 25,
+                  "name": "developerExperience",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Project developer experience",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "totalProjects",
+                          "type": "number",
+                          "label": "Total number of projects developed",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "projectTypes",
+                          "type": "string",
+                          "label": "Project types",
+                          "options": null,
+                          "description": "Comma-separated. Values should align with CDOP 'project type' enumerated list, or 'Other'."
+                        },
+                        {
+                          "name": "registries",
+                          "type": "string",
+                          "label": "Associated registries",
+                          "options": null,
+                          "description": "Comma-separated. Values should align with CDOP 'registry' enumerated list, or 'Other'."
+                        },
+                        {
+                          "name": "countries",
+                          "type": "string",
+                          "label": "Project countries",
+                          "options": null,
+                          "description": "Comma-separated. Values should align with CDOP 'Country Name English Short Name' enumerated list, or 'Other'."
+                        },
+                        {
+                          "name": "links",
+                          "type": "string",
+                          "label": "Relevant links or documentation",
+                          "options": null,
+                          "description": null
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Showcase the project developer's experience with developing other carbon credit projects that are relevant to the specific procurement request. Add rows as necessary."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "stage2",
+      "label": "Stage 2: Project Diligence",
+      "steps": [
+        {
+          "name": "legalReputational",
+          "label": "Legal & Reputational Disclosure",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 26,
+                  "name": "legalActions",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Active or threatened legal actions",
+                  "table": null,
+                  "options": ["Yes", "No", "Not Applicable"],
+                  "description": "Are there any active or threatened actions, litigations, investigations or convictions against the project owners, project developers, shareholders, or members of the project management team? These investigations could be related to corruption, forced labor, gender-based violence/harassment, or other non-compliance with financial, social, or environmental regulations, impacts to local/indigenous communities, or any other matter that could be reasonably expected to negatively impact your entity or the project's reputation."
+                },
+                {
+                  "id": 27,
+                  "name": "legalActionsDescription",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Description of legal actions",
+                  "table": null,
+                  "options": [],
+                  "description": "If yes to the above, describe the actions, investigations and/or convictions, alongside the entities or individuals involved. If issues have been or are being remediated, provide the steps taken to fully address the issues identified. (≤500 words)"
+                },
+                {
+                  "id": 28,
+                  "name": "terminatedForNonPerformance",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Ever terminated for non-performance on a contract",
+                  "table": null,
+                  "options": ["Yes", "No"],
+                  "description": "Has the project developer or affiliated implementation partners ever been terminated for non-performance on a contract?"
+                },
+                {
+                  "id": 29,
+                  "name": "bankruptcy",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Ever filed or petitioned for bankruptcy",
+                  "table": null,
+                  "options": ["Yes", "No"],
+                  "description": "Has the project developer or affiliated implementation partners ever filed or petitioned for bankruptcy?"
+                },
+                {
+                  "id": 30,
+                  "name": "negativePress",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Negative press disclosure",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe any relevant negative press that the organizations responsible for the implementation of this project, or the project itself has received. Disclose any citations and/or links to articles if available. (≤200 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "landTenure",
+          "label": "Land Tenure & Ownership",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 31,
+                  "name": "carbonRights",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Carbon rights",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe the carbon rights of the project area. Include how the project addresses customary and statutory land rights, and identify precedents within the same or nearby jurisdictions, if possible. (≤500 words)"
+                },
+                {
+                  "id": 32,
+                  "name": "landSelectionStrategy",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Land/site selection strategy and ownership",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe your land/site selection strategy and the ultimate owner(s) of the land involved (e.g. acquisition or leases from individual private landowners, collective landowners, or public concession model, etc.) as applicable. (≤500 words)"
+                },
+                {
+                  "id": 33,
+                  "name": "landAccessStatus",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Land access / project siting status",
+                  "table": null,
+                  "options": [
+                    "Contract(s) signed for all of the planned project area",
+                    "Contract(s) signed for some of the planned project area",
+                    "Contract(s) in negotiation for all of the planned project area",
+                    "Contract(s) in negotiation for some of the planned project area",
+                    "Verbal discussions underway for some or all of the planned project area",
+                    "Landowner/siting agreements not yet in negotiations",
+                    "Other"
+                  ],
+                  "description": "Select the most applicable option for the project's status in securing land access/project siting."
+                },
+                {
+                  "id": 34,
+                  "name": "landOwnershipUnderStatute",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Land ownership granted by competent authority",
+                  "table": null,
+                  "options": ["Yes", "No", "Not Applicable"],
+                  "description": "Can you confirm that all the land ownership associated with the project is granted under statute, regulation, or decree by a competent authority of the country in which your project is being developed?"
+                },
+                {
+                  "id": 35,
+                  "name": "permitsRequired",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Permits or formal permissions",
+                  "table": null,
+                  "options": [],
+                  "description": "What permits or other forms of formal permission (e.g., from regulatory agencies) do you require, if any, to engage in the implementation of your project? What else might be required in the future as you scale? (≤500 words)"
+                },
+                {
+                  "id": 36,
+                  "name": "indigenousCommunitiesEngagement",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Indigenous communities engagement (UNDRIP, ILO 169)",
+                  "table": null,
+                  "options": [],
+                  "description": "If Indigenous communities are impacted by the project, describe which communities and their location relative to the project, and explain what steps the project has taken to conform with the UN Declaration on the Rights of Indigenous Peoples and ILO's Convention 169 on Indigenous and Tribal Peoples. If no Indigenous communities are impacted or involved in the project, indicate N/A. (≤500 words)"
+                },
+                {
+                  "id": 37,
+                  "name": "fpicAgreements",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Written FPIC agreements in place",
+                  "table": null,
+                  "options": ["Yes", "No", "Not Applicable"],
+                  "description": "Do you have written agreements in place in which participating indigenous peoples and local communities (IPLCs) give free, prior and informed consent (FPIC) for their enrollment in the project?"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "socioEnvironmental",
+          "label": "Socio-Environmental Impacts & Indicators",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 38,
+                  "name": "stakeholderMappingMethod",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Stakeholder mapping method",
+                  "table": null,
+                  "options": [],
+                  "description": "Is stakeholder mapping for the project conducted in-house, by external consultants, by independent advisors, or through a combination of these methods? (≤20 words)"
+                },
+                {
+                  "id": 39,
+                  "name": "communityContext",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Community context around project area",
+                  "table": null,
+                  "options": [],
+                  "description": "Tell us about who lives in and around the project area, including potential marginalized communities, migration trends, IPLCs in or near the project area, or rural or urban communities that could be positively or negatively affected by the project. (≤500 words)"
+                },
+                {
+                  "id": 40,
+                  "name": "localRisksAndMitigation",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Local social or environmental risks and mitigation",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe any local social or environmental risks the project faces. For each identified risk, describe potential impacts on the identified groups above and outline mitigation strategies you would take to reduce or manage the risk. Examples of risks include altering stakeholders' rights to food, housing, education, etc., perpetuating unequal power dynamics, habitat fragmentation due to project infrastructure, changes to water flow or quality, changes to soil conditions, or other attributes surfaced by the project's risk assessment process. (≤200 words)"
+                },
+                {
+                  "id": 41,
+                  "name": "socioEnvironmentalOutcomesSelection",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Selection of socio-environmental outcomes",
+                  "table": null,
+                  "options": [],
+                  "description": "How did you determine which socio-environmental outcomes are most important for the project to achieve or protect? Describe any methodology or framework you use or plan to use to select these outcomes and explain how they address the project's identified social and environmental risks. (≤500 words)"
+                },
+                {
+                  "id": 42,
+                  "name": "socioEnvironmentalMonitoring",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Socio-environmental monitoring approach",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe how you will monitor socio-environmental outcomes, including data collection methods, frequency, responsibilities, and any third-party verification where applicable. (≤500 words)"
+                },
+                {
+                  "id": 43,
+                  "name": "sdgs",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Sustainable Development Goals addressed",
+                  "table": null,
+                  "options": [
+                    "1. No Poverty",
+                    "2. Zero Hunger",
+                    "3. Good Health and Well Being",
+                    "4. Quality Education",
+                    "5. Gender Equality",
+                    "6. Clean Water and Sanitation",
+                    "7. Affordable and Clean Energy",
+                    "8. Decent Work and Economic Growth",
+                    "9. Industry, Innovation, and Infrastructure",
+                    "10. Reduced Inequalities",
+                    "11. Sustainable Cities and Communities",
+                    "12. Responsible Consumption and Production",
+                    "13. Climate Action",
+                    "14. Life Below Water",
+                    "15. Life on Land",
+                    "16. Peace, Justice, and Strong Institutions",
+                    "17. Partnership for the Goals",
+                    "18. Not Applicable"
+                  ],
+                  "description": "Select which Sustainable Development Goals the project works to address."
+                },
+                {
+                  "id": 44,
+                  "name": "grievanceProcedure",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Grievance procedure and reported grievances",
+                  "table": null,
+                  "options": [],
+                  "description": "Does the project have a procedure or policy to address disputes or grievances? If so, detail your procedure and any grievances reported to date. (≤200 words)"
+                },
+                {
+                  "id": 45,
+                  "name": "iucnEcoregion",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "IUCN ecoregion(s) or ecosystem(s)",
+                  "table": null,
+                  "options": [],
+                  "description": "Using the IUCN's Global Ecosystem Typology, list the ecoregion(s) or ecosystem(s) the project is located in. (≤50 words)"
+                },
+                {
+                  "id": 46,
+                  "name": "resourceNeeds",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Water/land/energy/other natural resource needs",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe the water/land/energy/other natural resource needs of the project in the first few years, and describe how these resource needs may evolve in the coming decade. Example descriptions may include kWh, gallons of water, or hectares per ton of carbon sequestered, depending on the type of project. (≤500 words)"
+                },
+                {
+                  "id": 47,
+                  "name": "wasteAndByproducts",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Waste streams, residual materials, and byproducts",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe any waste streams, residual materials, or by-products associated with project activities, and how the project will manage these wastes to minimize health and environmental risks. Additionally, identify any other potential health and/or environmental risks and the mitigation strategies for each. (≤200 words)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "stage3",
+      "label": "Stage 3: Financial & Commercial Review",
+      "steps": [
+        {
+          "name": "projectFinancials",
+          "label": "Project Financials",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 48,
+                  "name": "additionalRevenueStreams",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Additional revenue streams",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "stream",
+                          "type": "string",
+                          "label": "Revenue stream",
+                          "options": [
+                            "Sale of physical products or commodities",
+                            "Sale of environmental or ecosystem services",
+                            "Energy generation or sale",
+                            "Waste management or processing revenues",
+                            "Government payments or subsidies",
+                            "Tourism / Recreation",
+                            "Other (please specify)",
+                            "None, the only revenue is from carbon credit sale"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "streamDescription",
+                          "type": "string",
+                          "label": "Description of revenue stream",
+                          "options": null,
+                          "description": "Explain how and why it will occur during the project."
+                        },
+                        {
+                          "name": "estimatedContribution",
+                          "type": "number",
+                          "label": "Estimated contribution to project finances",
+                          "options": null,
+                          "description": "Numeric — e.g. % share or USD."
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "What types of revenue streams, if any, are planned for your project in addition to carbon credits? Select all that apply and explain each item's role in the project's financial model. Add rows as necessary."
+                },
+                {
+                  "id": 49,
+                  "name": "fundingSources",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Funding sources for project development",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "entityName",
+                          "type": "string",
+                          "label": "Name of entity providing finance",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "source",
+                          "type": "string",
+                          "label": "Funding source",
+                          "options": [
+                            "Philanthropic donors",
+                            "Venture Capital or Private Equity",
+                            "Public or government funding",
+                            "Family Office",
+                            "Subsidiary or larger organization",
+                            "Self-funding",
+                            "Other"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "type",
+                          "type": "string",
+                          "label": "Type",
+                          "options": ["Grant", "Equity", "Loan", "Debt", "Other"],
+                          "description": null
+                        },
+                        {
+                          "name": "amountUsd",
+                          "type": "number",
+                          "label": "Amount (USD)",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "status",
+                          "type": "string",
+                          "label": "Status",
+                          "options": ["Secured", "Identified", "In Discussion", "Not Secured"],
+                          "description": null
+                        },
+                        {
+                          "name": "notes",
+                          "type": "string",
+                          "label": "Additional notes",
+                          "options": null,
+                          "description": null
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Provide details of funding sources for your project's development, including secured and planned funding. Add rows as necessary."
+                },
+                {
+                  "id": 50,
+                  "name": "deriskingInstruments",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "De-risking instruments",
+                  "table": null,
+                  "options": [],
+                  "description": "List any additional de-risking instruments the project has obtained or is in the process of obtaining (i.e. insurance products, loan guarantees, etc.). (≤200 words)"
+                },
+                {
+                  "id": 51,
+                  "name": "offtakeAgreements",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Offtake agreements and forward sales",
+                  "table": null,
+                  "options": [],
+                  "description": "Disclose any offtake agreements or forward sales and their status. (≤100 words)"
+                },
+                {
+                  "id": 52,
+                  "name": "wacc",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Weighted Average Cost of Capital (WACC)",
+                  "table": null,
+                  "options": [],
+                  "description": "What is the project's approximate weighted average cost of capital (WACC)? (≤50 words)"
+                },
+                {
+                  "id": 53,
+                  "name": "financingMilestones",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Key project development and financing milestones",
+                  "table": null,
+                  "options": [],
+                  "description": "Provide key project development and financing milestones. Include relevant final investment decision (FID) milestones. (≤500 words)"
+                },
+                {
+                  "id": 54,
+                  "name": "runwayWithConfirmedFunding",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Operational runway with confirmed funding",
+                  "table": null,
+                  "options": [],
+                  "description": "How long could your entity sustain operations with confirmed sources of funding? (≤100 words)"
+                },
+                {
+                  "id": 55,
+                  "name": "fortuneBuyers",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Fortune 100/500 buyers",
+                  "table": null,
+                  "options": [],
+                  "description": "How many credit buyers do you have that are Fortune 100 or Fortune 500 companies, and in which business sectors? (≤20 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "commercialOffer",
+          "label": "Commercial Offer",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 56,
+                  "name": "creditsAvailable",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Credits available for delivery under this proposal",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "vintageYear",
+                          "type": "string",
+                          "label": "Vintage year",
+                          "options": [
+                            "2008","2009","2010","2011","2012","2013","2014","2015","2016","2017",
+                            "2018","2019","2020","2021","2022","2023","2024","2025","2026","2027",
+                            "2028","2029","2030","2031","2032","2033","2034","2035","2036","2037",
+                            "2038","2039","2040","2041","2042","2043","2044","2045","2046","2047",
+                            "2048","2049","2050","2051","2052","2053","2054","2055","2056","2057",
+                            "2058","2059","2060"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "deliveryYear",
+                          "type": "string",
+                          "label": "Delivery year",
+                          "options": [
+                            "2008","2009","2010","2011","2012","2013","2014","2015","2016","2017",
+                            "2018","2019","2020","2021","2022","2023","2024","2025","2026","2027",
+                            "2028","2029","2030","2031","2032","2033","2034","2035","2036","2037",
+                            "2038","2039","2040","2041","2042","2043","2044","2045","2046","2047",
+                            "2048","2049","2050","2051","2052","2053","2054","2055","2056","2057",
+                            "2058","2059","2060"
+                          ],
+                          "description": null
+                        },
+                        {
+                          "name": "tonsRemovals",
+                          "type": "number",
+                          "label": "Tons of removals",
+                          "options": null,
+                          "description": "Leave blank if not applicable."
+                        },
+                        {
+                          "name": "tonsReductions",
+                          "type": "number",
+                          "label": "Tons of reductions/avoidance",
+                          "options": null,
+                          "description": "Leave blank if not applicable."
+                        },
+                        {
+                          "name": "pricePerTon",
+                          "type": "number",
+                          "label": "Price per ton (USD)",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "pricingValidityDays",
+                          "type": "number",
+                          "label": "Pricing validity period (days)",
+                          "options": null,
+                          "description": null
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Provide the volume of credits available for delivery under this proposal, and the project's maximum expansion potential over time. Clearly distinguish between volumes included in this offer and additional potential volumes not included. Volumes included in this offer should reflect only the credits available for contracting under this RFP proposal. Add rows as necessary."
+                },
+                {
+                  "id": 57,
+                  "name": "costUncertaintyDrivers",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Drivers of cost uncertainty",
+                  "table": null,
+                  "options": [],
+                  "description": "What are the primary drivers contributing to cost uncertainty (e.g., labor rates, material costs, regulatory timelines, market conditions)? (≤200 words)"
+                },
+                {
+                  "id": 58,
+                  "name": "buyerSeniority",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Buyer seniority applicable to offered credits",
+                  "table": null,
+                  "options": [],
+                  "description": "Are credits that are indicated in the offer potentially subject to buyer seniority? (≤20 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "beneficiaries",
+          "label": "Beneficiaries & Benefit Sharing",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 59,
+                  "name": "beneficiaryContributions",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Contributions expected from beneficiaries",
+                  "table": null,
+                  "options": [],
+                  "description": "Identify what contributions (i.e., financial resources, time, land/labor inputs, support, etc.) that the project beneficiaries are expected to contribute to the project. (≤200 words)"
+                },
+                {
+                  "id": 60,
+                  "name": "benefitDistribution",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Benefit distribution details",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "beneficiary",
+                          "type": "string",
+                          "label": "Name of beneficiary or beneficiary group",
+                          "options": null,
+                          "description": "Specific recipient(s) receiving the benefit."
+                        },
+                        {
+                          "name": "benefitType",
+                          "type": "string",
+                          "label": "Benefit type",
+                          "options": null,
+                          "description": "E.g., income, jobs, cash payments, revenue share, product sales, materials, ecosystem services."
+                        },
+                        {
+                          "name": "benefitDescription",
+                          "type": "string",
+                          "label": "Description of benefit",
+                          "options": null,
+                          "description": "Specific explanation or concrete example of what will be delivered."
+                        },
+                        {
+                          "name": "estimatedMonetaryValue",
+                          "type": "number",
+                          "label": "Estimated monetary value",
+                          "options": null,
+                          "description": "If available."
+                        },
+                        {
+                          "name": "formOfDistribution",
+                          "type": "string",
+                          "label": "Form of distribution",
+                          "options": null,
+                          "description": "E.g., cash, credit, transfers, in-kind."
+                        },
+                        {
+                          "name": "expectedDuration",
+                          "type": "string",
+                          "label": "Expected duration of benefit",
+                          "options": null,
+                          "description": "E.g., one-time, recurring, project lifetime, X years post-project."
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Describe both the monetary and non-monetary benefits provided to beneficiaries, including what they receive from the project and how those benefits are distributed. Add rows as necessary."
+                },
+                {
+                  "id": 61,
+                  "name": "carbonRevenueAllocation",
+                  "tier": 0,
+                  "type": "object",
+                  "label": "Carbon revenue allocation",
+                  "table": [
+                    {
+                      "rows": null,
+                      "columns": [
+                        {
+                          "name": "beneficiary",
+                          "type": "string",
+                          "label": "Name of beneficiary or beneficiary group",
+                          "options": null,
+                          "description": null
+                        },
+                        {
+                          "name": "revenueStream",
+                          "type": "string",
+                          "label": "Revenue stream",
+                          "options": null,
+                          "description": "E.g., carbon credits, forward sales, pre-purchase agreements."
+                        },
+                        {
+                          "name": "percentageShare",
+                          "type": "number",
+                          "label": "Percentage share (%)",
+                          "options": null,
+                          "description": "Beneficiary's share of the revenue stream identified."
+                        },
+                        {
+                          "name": "formOfDistribution",
+                          "type": "string",
+                          "label": "Form of distribution",
+                          "options": null,
+                          "description": "E.g., credits, cash, in-kind."
+                        },
+                        {
+                          "name": "paymentStructure",
+                          "type": "string",
+                          "label": "Payment structure",
+                          "options": null,
+                          "description": "E.g., one-time, quarterly, annual, milestone-based."
+                        },
+                        {
+                          "name": "estimatedMonetaryValue",
+                          "type": "number",
+                          "label": "Estimated monetary value",
+                          "options": null,
+                          "description": "If available."
+                        }
+                      ]
+                    }
+                  ],
+                  "options": [],
+                  "description": "Describe how carbon credit revenue streams are allocated among beneficiaries. Percentage Share (%) refers to the beneficiary's share of the revenue stream identified. Add rows as necessary."
+                },
+                {
+                  "id": 62,
+                  "name": "benefitSharingPlanDevelopment",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Benefit sharing plan development",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe the development of the benefit sharing plan, including: how beneficiaries, benefit types, and allocation approaches were determined; the consultation and decision-making process with beneficiaries; whether and how beneficiaries have agreed to the plan, and supporting evidence; any relevant existing or emerging regulations on benefit sharing (e.g., revenue sharing requirements with communities or government). (≤500 words)"
+                },
+                {
+                  "id": 63,
+                  "name": "unanticipatedUpsideAllocation",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Allocation of unanticipated financial upside",
+                  "table": null,
+                  "options": [],
+                  "description": "Does the project have a transparent and verifiable process for allocating unanticipated financial upside (i.e. revenues resulting from higher-than-expected carbon credit prices or project performance) to local communities or other stakeholders? Describe the process, decision-making authority, and reporting arrangements. (≤200 words)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "appendix",
+      "label": "Appendix: Additional Diligence",
+      "steps": [
+        {
+          "name": "additionality",
+          "label": "Additionality",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 64,
+                  "name": "governmentSubsidies",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Government subsidies, grants, or incentives",
+                  "table": null,
+                  "options": [],
+                  "description": "If applicable, describe any government subsidies, grants, regulatory incentives, policies or other relevant laws or regulations that support or promote activities in the project area. Please include: type and status (e.g., confirmed/awarded, scheduled, or expected/speculative); estimated contribution to total project revenue (%); relevant program details, including any applicable sector-specific programs (e.g., agricultural subsidies); and key eligibility requirements. (≤500 words)"
+                },
+                {
+                  "id": 65,
+                  "name": "nationalPolicyContext",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "National and sub-national policy context",
+                  "table": null,
+                  "options": [],
+                  "description": "Briefly describe the key national and/or sub-national policies, regulations, or government frameworks relevant to the project's carbon market activity. Include any policies or regulations that materially affect the project or its eligibility to generate carbon credits; the relevant government ministry or public authority, where applicable; and a brief explanation of how or if the project aligns with national climate policies or commitments (e.g., NDCs or national climate strategies). (≤200 words)"
+                },
+                {
+                  "id": 66,
+                  "name": "hostCountryAuthorization",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Host country authorization status",
+                  "table": null,
+                  "options": [
+                    "Yes – obtained",
+                    "Yes – pending",
+                    "Planned",
+                    "No",
+                    "Not Applicable"
+                  ],
+                  "description": "Has the project sought or obtained host country authorization?"
+                },
+                {
+                  "id": 67,
+                  "name": "intendedCreditUse",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Intended use of credits",
+                  "table": null,
+                  "options": [
+                    "Voluntary Carbon Market Claims",
+                    "NDC Achievement",
+                    "Article 6 Authorized Transfer",
+                    "Other international mitigation purpose (e.g., CORSIA)",
+                    "Other (Specify)"
+                  ],
+                  "description": "What is the intended use of the credits?"
+                },
+                {
+                  "id": 68,
+                  "name": "correspondingAdjustments",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Corresponding adjustments expected",
+                  "table": null,
+                  "options": ["Yes", "No", "Not yet determined", "Not applicable"],
+                  "description": "Are corresponding adjustments expected or necessary?"
+                },
+                {
+                  "id": 69,
+                  "name": "managingMethodologyUpdates",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Management of methodology updates and crediting rule changes",
+                  "table": null,
+                  "options": [],
+                  "description": "How does the project plan to manage methodology updates, baseline reassessments, and changes in crediting rules? (≤200 words)"
+                },
+                {
+                  "id": 70,
+                  "name": "viabilityWithoutCarbonRevenue",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Project viability in absence of carbon credit sales",
+                  "table": null,
+                  "options": [],
+                  "description": "Please describe how and why the project may be able to continue in the absence of carbon credit sales. If the project includes other revenue streams, please explain how carbon revenue is required to make the project viable. (≤500 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "durability",
+          "label": "Durability & Permanence",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 71,
+                  "name": "durabilityRisks",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Durability risks and evolution over time",
+                  "table": null,
+                  "options": [],
+                  "description": "What durability risks does your project face and how are they expected to change over time? Include physical risks (e.g. leakage, decomposition and decay, damage, reversal, etc.), socioeconomic risks (e.g. mismanagement of storage, decision to consume or combust derived products, etc.), and outline any fundamental uncertainties about the underlying technological, geochemical or biological process. (≤500 words)"
+                },
+                {
+                  "id": 72,
+                  "name": "durabilityGuaranteeTerm",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Durability guarantee term (years)",
+                  "table": null,
+                  "options": [],
+                  "description": "What is the project durability guarantee term (years)? This is the number of years for which you will guarantee that the carbon remains sequestered and will offer compensation for any reversal. (≤50 words)"
+                },
+                {
+                  "id": 73,
+                  "name": "nonPermanenceDiscount",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Non-permanence discount applied",
+                  "table": null,
+                  "options": [],
+                  "description": "Has a non-permanence discount been applied? If yes, what is the rate as a percentage of estimated emissions reductions? (≤50 words)"
+                },
+                {
+                  "id": 74,
+                  "name": "durabilityGuaranteeMechanism",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Durability guarantee mechanism",
+                  "table": null,
+                  "options": [],
+                  "description": "Briefly explain the project durability guarantee: who is liable to remediate or compensate for reversals? In what form will you provide compensation (e.g., project-level or registry-level buffer pools, monetary permanence reserves, horizontal stacking, clawback provisions, risk-of-reversal discounts in original crediting, or other compensatory mechanisms)? Specify any differences in proposed compensation between intentional/avoidable reversals and unintentional/unavoidable reversals. If your proposed compensation includes a buffer pool, specify (1) the percentage of project removal metric tons and annual volume that will be contributed to the buffer pool, and (2) the current volume and composition of this pool. Specify if the buffer pool includes both removal and avoidance credits. (≤500 words)"
+                },
+                {
+                  "id": 75,
+                  "name": "postCreditingDurability",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Post-crediting durability mechanisms",
+                  "table": null,
+                  "options": [],
+                  "description": "If relevant, how will the project ensure that sequestered CO2e remains durable after the end of the crediting period? Describe the mechanisms that incentivize CO2e storage beyond this period, such as legal protections (e.g., conservation easements) or non-carbon economic incentives for landholders, or any other measures that support long-term permanence. (≤500 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "quantificationUncertainty",
+          "label": "Quantification Uncertainty",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 76,
+                  "name": "uncertaintyAssessment",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Uncertainty assessment result",
+                  "table": null,
+                  "options": [],
+                  "description": "Has an uncertainty assessment been completed? If yes, what is the resulting uncertainty level as a percentage of estimated emissions reductions/removals? (≤50 words)"
+                },
+                {
+                  "id": 77,
+                  "name": "quantificationApproach",
+                  "tier": 0,
+                  "type": "array",
+                  "label": "Primary emissions quantification approach",
+                  "table": null,
+                  "options": [
+                    "Direct Measurement",
+                    "Measurement and Modeling",
+                    "Modeling only",
+                    "Emission factors or default values",
+                    "Remote Sensing or Satellite Imagery",
+                    "Other (Specify)"
+                  ],
+                  "description": "What is the project's primary emissions quantification approach?"
+                },
+                {
+                  "id": 78,
+                  "name": "sourcesOfUncertainty",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Sources of uncertainty",
+                  "table": null,
+                  "options": [],
+                  "description": "What are your project's sources of uncertainty? (≤500 words)"
+                },
+                {
+                  "id": 79,
+                  "name": "pilotLocalDataUsed",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Pilot or locally collected data used to validate estimates",
+                  "table": null,
+                  "options": ["Yes", "No"],
+                  "description": "Has the project used pilot and/or locally collected data to validate the estimated project emissions or removals?"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "leakage",
+          "label": "Leakage",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 80,
+                  "name": "leakageDiscount",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Leakage discount applied",
+                  "table": null,
+                  "options": [],
+                  "description": "Has a leakage discount been applied? If yes, what is the rate as a percentage of estimated emissions reductions? (≤50 words)"
+                },
+                {
+                  "id": 81,
+                  "name": "biomassWasteRisks",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Risks to biomass/waste/byproduct streams",
+                  "table": null,
+                  "options": [],
+                  "description": "Describe risks that could lead to unintended consequences for your proposed biomass, waste, or byproduct stream (e.g. effects on supply chains, pricing, alternative uses of the waste, etc.) for both inputs and outputs of the process. For each identified risk, indicate the geographic scope (local, national, international); the potential impacts; mitigation strategies for reducing or managing the risk; and relevant standards or scientific literature used to inform your analysis. (≥500 words)"
+                },
+                {
+                  "id": 82,
+                  "name": "leakageBeyondMethodology",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Leakage handling beyond methodology requirements",
+                  "table": null,
+                  "options": [],
+                  "description": "Please describe how your project addresses leakage beyond any methodology requirements. Include plans for monitoring and accounting for leakage in design and operations. (≥500 words)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "mrv",
+          "label": "MRV",
+          "sections": [
+            {
+              "name": "default",
+              "label": "",
+              "fields": [
+                {
+                  "id": 83,
+                  "name": "mmrvBeyondMethodology",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "MMRV practices beyond methodology requirements",
+                  "table": null,
+                  "options": [],
+                  "description": "Please briefly describe any pieces of the project's MMRV plan which go above and beyond methodological requirements. (≤500 words)"
+                },
+                {
+                  "id": 84,
+                  "name": "postCreditingMonitoringPeriod",
+                  "tier": 0,
+                  "type": "string",
+                  "label": "Post-crediting monitoring period and cadence",
+                  "table": null,
+                  "options": [],
+                  "description": "What is the anticipated duration (in years) of the post-crediting monitoring period? How does the cadence play out over time (e.g. intensive up front monitoring, phase out over time, etc.)? (≤200 words)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/releases/tccp/2026-08-05/tccp.json
+++ b/releases/tccp/2026-08-05/tccp.json
@@ -1,8 +1,8 @@
 {
-  "$framework": "https://github.com/RMI/ccdf/blob/main/releases/ccpt/2026-08-05/ccpt.json",
+  "$framework": "https://github.com/RMI/ccdf/blob/main/releases/tccp/2026-08-05/tccp.json",
   "version": "1.0.0",
-  "name": "ccpt",
-  "title": "Carbon Credit Procurement Template",
+  "name": "tccp",
+  "title": "Template for Carbon Credit Procurement",
   "topic": [
     {
       "name": "stage1",


### PR DESCRIPTION
- Adds `releases/ccpt/2026-08-05/ccpt.json` (Beyond Alliance procurement template as a 3rd framework variant. 84 fields, 4 topics.)
- Wires CCPT into the framework selector in `index.html`.
